### PR TITLE
🔨 chore: sync dev to main (2026-03-09)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,11 @@ RUN set -e && \
 COPY . .
 
 # run build standalone for docker version
-RUN npm run build:docker
+# Avoid triggering the full lint pipeline in Docker build, which can fail on
+# workspace-only type checks unrelated to runtime bundles.
+RUN ./node_modules/.bin/tsx scripts/prebuild.mts && \
+    NODE_OPTIONS=--max-old-space-size=8192 DOCKER=true ./node_modules/.bin/next build --webpack && \
+    npm run build-sitemap
 
 # Prepare desktop export assets for Electron packaging (if generated)
 RUN set -e && \
@@ -136,6 +140,8 @@ COPY --from=builder /app/scripts/_shared /app/scripts/_shared
 RUN set -e && \
     addgroup -S -g 1001 nodejs && \
     adduser -D -G nodejs -H -S -h /app -u 1001 nextjs && \
+    mkdir -p /app/node_modules/@napi-rs && \
+    node -e "const fs=require('node:fs'); const path=require('node:path'); const root='/app/node_modules'; const scopeDir=path.join(root,'@napi-rs'); const canvasDir=path.join(scopeDir,'canvas'); if (fs.existsSync(canvasDir)) { const canvasPkg=JSON.parse(fs.readFileSync(path.join(canvasDir,'package.json'),'utf8')); for (const [depName, version] of Object.entries(canvasPkg.optionalDependencies || {})) { if (!depName.startsWith('@napi-rs/canvas-')) continue; const shortName=depName.split('/')[1]; const targetDir=path.join(root,'.pnpm','@napi-rs+' + shortName + '@' + version,'node_modules','@napi-rs',shortName); if (!fs.existsSync(targetDir)) continue; const linkPath=path.join(scopeDir,shortName); fs.rmSync(linkPath,{ force:true, recursive:true }); fs.symlinkSync(path.relative(scopeDir,targetDir),linkPath,'dir'); } }" && \
     chown -R nextjs:nodejs /app /etc/proxychains4.conf
 
 ## Production image, copy all the files and run next

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -773,11 +773,6 @@
       "count": 1
     }
   },
-  "src/store/file/slices/chat/action.ts": {
-    "no-console": {
-      "count": 1
-    }
-  },
   "src/store/file/slices/chunk/action.ts": {
     "no-unused-private-class-members": {
       "count": 1

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -185,6 +185,7 @@ export class MessagesEngine {
       new KnowledgeInjector({
         fileContents: knowledge?.fileContents,
         knowledgeBases: knowledge?.knowledgeBases,
+        provider,
       }),
 
       // =============================================
@@ -228,9 +229,9 @@ export class MessagesEngine {
       new PageEditorContextInjector({
         enabled: isPageEditorEnabled,
         // Use direct pageContentContext if provided (server-side), otherwise build from initialContext + stepContext (frontend)
-        pageContentContext: pageContentContext
-          ? pageContentContext
-          : initialContext?.pageEditor
+        pageContentContext:
+          pageContentContext ||
+          (initialContext?.pageEditor
             ? {
                 markdown: initialContext.pageEditor.markdown,
                 metadata: {
@@ -241,7 +242,7 @@ export class MessagesEngine {
                 // Use latest XML from stepContext if available, otherwise fallback to initial XML
                 xml: stepContext?.stepPageEditor?.xml || initialContext.pageEditor.xml,
               }
-            : undefined,
+            : undefined),
       }),
 
       // 11. GTD Todo injection (conditionally added, at end of last user message)

--- a/packages/context-engine/src/processors/MessageContent.ts
+++ b/packages/context-engine/src/processors/MessageContent.ts
@@ -1,5 +1,5 @@
 import { filesPrompts } from '@lobechat/prompts';
-import type { MessageContentPart } from '@lobechat/types';
+import type { ChatFileItem, MessageContentPart } from '@lobechat/types';
 import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
 import { parseDataUri } from '@lobechat/utils/uriParser';
 import { isDesktopLocalStaticServerUrl } from '@lobechat/utils/url';
@@ -48,6 +48,13 @@ export interface MessageContentConfig {
 }
 
 export interface UserMessageContentPart {
+  file_url?: {
+    id?: string;
+    mimeType?: string;
+    name?: string;
+    size?: number;
+    url: string;
+  };
   googleThoughtSignature?: string;
   image_url?: {
     detail?: string;
@@ -56,7 +63,7 @@ export interface UserMessageContentPart {
   signature?: string;
   text?: string;
   thinking?: string;
-  type: 'text' | 'image_url' | 'thinking' | 'video_url';
+  type: 'text' | 'image_url' | 'thinking' | 'video_url' | 'file_url';
   video_url?: {
     url: string;
   };
@@ -170,6 +177,11 @@ export class MessageContentProcessor extends BaseProcessor {
       });
     }
 
+    // Keep native PDF parts for Vertex while preserving text injection fallback.
+    if (hasFiles) {
+      contentParts.push(...this.processNativeFileParts(message.fileList || []));
+    }
+
     // Process image content
     if (hasImages && this.config.isCanUseVision?.(this.config.model, this.config.provider)) {
       const imageContentParts = await this.processImageList(message.imageList || []);
@@ -226,6 +238,23 @@ export class MessageContentProcessor extends BaseProcessor {
       ...(message.tool_call_id && { tool_call_id: message.tool_call_id }),
       ...(message.name && { name: message.name }),
     };
+  }
+
+  private processNativeFileParts(fileList: ChatFileItem[]): UserMessageContentPart[] {
+    if (this.config.provider !== 'vertexai') return [];
+
+    return fileList
+      .filter((file) => file.fileType?.toLowerCase() === 'application/pdf' && !!file.url)
+      .map<UserMessageContentPart>((file) => ({
+        file_url: {
+          id: file.id,
+          mimeType: file.fileType,
+          name: file.name,
+          size: file.size,
+          url: file.url,
+        },
+        type: 'file_url',
+      }));
   }
 
   /**

--- a/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
+++ b/packages/context-engine/src/processors/__tests__/MessageContent.test.ts
@@ -1,11 +1,12 @@
 import type { ChatImageItem, ChatVideoItem, UIChatMessage } from '@lobechat/types';
+import type * as ImageToBase64Module from '@lobechat/utils/imageToBase64';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { PipelineContext } from '../../types';
 import { MessageContentProcessor } from '../MessageContent';
 
 vi.mock('@lobechat/utils/imageToBase64', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@lobechat/utils/imageToBase64')>();
+  const actual = (await importOriginal()) as typeof ImageToBase64Module;
   return {
     ...actual,
     imageUrlToBase64: vi.fn().mockResolvedValue({
@@ -286,6 +287,91 @@ describe('MessageContentProcessor', () => {
 
       // Should not include file context
       expect(result.messages[0].content).toBe('Hello');
+    });
+
+    it('should append native PDF file parts for Vertex while keeping text fallback', async () => {
+      mockIsCanUseVision.mockReturnValue(false);
+
+      const processor = new MessageContentProcessor({
+        model: 'gemini-2.5-flash',
+        provider: 'vertexai',
+        isCanUseVision: mockIsCanUseVision,
+        fileContext: { enabled: true },
+      });
+
+      const messages: UIChatMessage[] = [
+        {
+          id: 'test',
+          role: 'user',
+          content: 'Read the attached PDF',
+          fileList: [
+            {
+              id: 'file-pdf-1',
+              name: 'test.pdf',
+              fileType: 'application/pdf',
+              size: 123,
+              url: 'https://example.com/test.pdf',
+            },
+          ],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+
+      const result = await processor.process(createContext(messages));
+
+      expect(Array.isArray(result.messages[0].content)).toBe(true);
+      const content = result.messages[0].content as any[];
+      expect(content).toHaveLength(2);
+      expect(content[0].type).toBe('text');
+      expect(content[0].text).toContain('SYSTEM CONTEXT');
+      expect(content[1]).toEqual({
+        file_url: {
+          id: 'file-pdf-1',
+          mimeType: 'application/pdf',
+          name: 'test.pdf',
+          size: 123,
+          url: 'https://example.com/test.pdf',
+        },
+        type: 'file_url',
+      });
+    });
+
+    it('should not append native file parts for non-Vertex providers', async () => {
+      mockIsCanUseVision.mockReturnValue(false);
+
+      const processor = new MessageContentProcessor({
+        model: 'gpt-4o',
+        provider: 'openai',
+        isCanUseVision: mockIsCanUseVision,
+        fileContext: { enabled: true },
+      });
+
+      const messages: UIChatMessage[] = [
+        {
+          id: 'test',
+          role: 'user',
+          content: 'Read the attached PDF',
+          fileList: [
+            {
+              id: 'file-pdf-1',
+              name: 'test.pdf',
+              fileType: 'application/pdf',
+              size: 123,
+              url: 'https://example.com/test.pdf',
+            },
+          ],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ];
+
+      const result = await processor.process(createContext(messages));
+
+      expect(Array.isArray(result.messages[0].content)).toBe(true);
+      const content = result.messages[0].content as any[];
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe('text');
     });
   });
 

--- a/packages/context-engine/src/providers/KnowledgeInjector.ts
+++ b/packages/context-engine/src/providers/KnowledgeInjector.ts
@@ -1,17 +1,23 @@
 import type { FileContent, KnowledgeBaseInfo } from '@lobechat/prompts';
 import { promptAgentKnowledge } from '@lobechat/prompts';
+import type { UserMessageContentPart } from '@lobechat/types';
 import debug from 'debug';
 
 import { BaseFirstUserContentProvider } from '../base/BaseFirstUserContentProvider';
-import type { PipelineContext, ProcessorOptions } from '../types';
+import type { Message, PipelineContext, ProcessorOptions } from '../types';
 
 const log = debug('context-engine:provider:KnowledgeInjector');
+const VERTEX_NATIVE_PDF_MIME_TYPE = 'application/pdf';
+
+type FileUrlPart = Extract<UserMessageContentPart, { type: 'file_url' }>;
 
 export interface KnowledgeInjectorConfig {
   /** File contents to inject */
   fileContents?: FileContent[];
   /** Knowledge bases to inject */
   knowledgeBases?: KnowledgeBaseInfo[];
+  /** Model provider, used to enable provider-specific knowledge injection */
+  provider?: string;
 }
 
 /**
@@ -29,8 +35,71 @@ export class KnowledgeInjector extends BaseFirstUserContentProvider {
     super(options);
   }
 
+  private getTextualFileContents() {
+    return (this.config.fileContents || []).filter((file) => !!file.error || !!file.content);
+  }
+
+  private getNativePdfParts(): FileUrlPart[] {
+    if (this.config.provider !== 'vertexai') return [];
+
+    return (this.config.fileContents || [])
+      .filter(
+        (file) =>
+          file.fileType?.toLowerCase() === VERTEX_NATIVE_PDF_MIME_TYPE &&
+          typeof file.url === 'string' &&
+          file.url.length > 0,
+      )
+      .flatMap<FileUrlPart>((file) => {
+        if (!file.url) return [];
+
+        return [
+          {
+            file_url: {
+              id: file.fileId,
+              mimeType: file.fileType,
+              name: file.filename,
+              ...(typeof file.size === 'number' ? { size: file.size } : {}),
+              url: file.url,
+            },
+            type: 'file_url',
+          },
+        ];
+      });
+  }
+
+  private appendNativePdfParts(
+    message: Message,
+    nativePdfParts: FileUrlPart[],
+    textContent?: string | null,
+  ) {
+    if (nativePdfParts.length === 0) {
+      return textContent ? this.appendToMessage(message, textContent) : message;
+    }
+
+    const nextMessage = textContent ? this.appendToMessage(message, textContent) : message;
+    const currentContent = nextMessage.content;
+
+    if (typeof currentContent === 'string') {
+      return {
+        ...nextMessage,
+        content: [{ text: currentContent, type: 'text' }, ...nativePdfParts],
+        updatedAt: Date.now(),
+      };
+    }
+
+    if (Array.isArray(currentContent)) {
+      return {
+        ...nextMessage,
+        content: [...currentContent, ...nativePdfParts],
+        updatedAt: Date.now(),
+      };
+    }
+
+    return nextMessage;
+  }
+
   protected buildContent(_context: PipelineContext): string | null {
-    const fileContents = this.config.fileContents || [];
+    const fileContents = this.getTextualFileContents();
     const knowledgeBases = this.config.knowledgeBases || [];
 
     // Generate unified knowledge prompt
@@ -49,18 +118,57 @@ export class KnowledgeInjector extends BaseFirstUserContentProvider {
   }
 
   protected async doProcess(context: PipelineContext): Promise<PipelineContext> {
-    const result = await super.doProcess(context);
-
-    // Update metadata
     const fileContents = this.config.fileContents || [];
     const knowledgeBases = this.config.knowledgeBases || [];
+    const textualFileContents = this.getTextualFileContents();
+    const nativePdfParts = this.getNativePdfParts();
+    const formattedContent = promptAgentKnowledge({
+      fileContents: textualFileContents,
+      knowledgeBases,
+    });
 
-    if (fileContents.length > 0 || knowledgeBases.length > 0) {
-      result.metadata.knowledgeInjected = true;
-      result.metadata.filesCount = fileContents.length;
-      result.metadata.knowledgeBasesCount = knowledgeBases.length;
+    if (!formattedContent && nativePdfParts.length === 0) {
+      log('No knowledge to inject');
+      return this.markAsExecuted(context);
     }
 
-    return result;
+    const clonedContext = this.cloneContext(context);
+    const existingIndex = this.findSystemInjectionMessageIndex(clonedContext.messages);
+
+    if (existingIndex !== -1) {
+      clonedContext.messages[existingIndex] = this.appendNativePdfParts(
+        clonedContext.messages[existingIndex],
+        nativePdfParts,
+        formattedContent || null,
+      );
+    } else {
+      const firstUserIndex = this.findFirstUserMessageIndex(clonedContext.messages);
+
+      if (firstUserIndex === -1) {
+        return this.markAsExecuted(clonedContext);
+      }
+
+      const injectionMessage =
+        nativePdfParts.length === 0
+          ? this.createSystemInjectionMessage(formattedContent)
+          : {
+              ...this.createSystemInjectionMessage(''),
+              content: [
+                ...(formattedContent ? ([{ text: formattedContent, type: 'text' }] as const) : []),
+                ...nativePdfParts,
+              ],
+            };
+
+      clonedContext.messages.splice(firstUserIndex, 0, injectionMessage);
+    }
+
+    // Update metadata
+    if (fileContents.length > 0 || knowledgeBases.length > 0) {
+      clonedContext.metadata.knowledgeInjected = true;
+      clonedContext.metadata.filesCount = fileContents.length;
+      clonedContext.metadata.knowledgeBasesCount = knowledgeBases.length;
+    }
+
+    return this.markAsExecuted(clonedContext);
   }
 }

--- a/packages/context-engine/src/providers/__tests__/KnowledgeInjector.test.ts
+++ b/packages/context-engine/src/providers/__tests__/KnowledgeInjector.test.ts
@@ -134,6 +134,86 @@ describe('KnowledgeInjector', () => {
     });
   });
 
+  describe('vertex native pdf', () => {
+    it('should append native pdf file parts for vertex agent files', async () => {
+      const provider = new KnowledgeInjector({
+        fileContents: [
+          {
+            content: 'Extracted PDF text',
+            fileId: 'file-pdf-1',
+            fileType: 'application/pdf',
+            filename: 'license.pdf',
+            size: 2048,
+            url: 'https://example.com/license.pdf',
+          },
+        ],
+        provider: 'vertexai',
+      });
+
+      const context = createContext([{ content: 'Analyze the file', id: 'user-1', role: 'user' }]);
+
+      const result = await provider.process(context);
+
+      expect(Array.isArray(result.messages[0].content)).toBe(true);
+      expect(result.messages[0].content).toEqual([
+        {
+          text: `<agent_knowledge>
+<instruction>The following files are available. Refer to their content directly to answer questions. No knowledge bases are associated.</instruction>
+<files totalCount="1">
+<file id="file-pdf-1" name="license.pdf">
+Extracted PDF text
+</file>
+</files>
+</agent_knowledge>`,
+          type: 'text',
+        },
+        {
+          file_url: {
+            id: 'file-pdf-1',
+            mimeType: 'application/pdf',
+            name: 'license.pdf',
+            size: 2048,
+            url: 'https://example.com/license.pdf',
+          },
+          type: 'file_url',
+        },
+      ]);
+    });
+
+    it('should inject native pdf parts without empty xml fallback when extracted text is empty', async () => {
+      const provider = new KnowledgeInjector({
+        fileContents: [
+          {
+            content: '',
+            fileId: 'file-pdf-1',
+            fileType: 'application/pdf',
+            filename: 'scan.pdf',
+            size: 1024,
+            url: 'https://example.com/scan.pdf',
+          },
+        ],
+        provider: 'vertexai',
+      });
+
+      const context = createContext([{ content: 'Analyze the file', id: 'user-1', role: 'user' }]);
+
+      const result = await provider.process(context);
+
+      expect(result.messages[0].content).toEqual([
+        {
+          file_url: {
+            id: 'file-pdf-1',
+            mimeType: 'application/pdf',
+            name: 'scan.pdf',
+            size: 1024,
+            url: 'https://example.com/scan.pdf',
+          },
+          type: 'file_url',
+        },
+      ]);
+    });
+  });
+
   describe('integration with BaseFirstUserContentProvider', () => {
     it('should append to existing system injection message', async () => {
       const provider = new KnowledgeInjector({

--- a/packages/editor-runtime/src/EditorRuntime.ts
+++ b/packages/editor-runtime/src/EditorRuntime.ts
@@ -1,5 +1,4 @@
 import type { PageContentContext } from '@lobechat/prompts';
-import type { IEditor } from '@lobehub/editor';
 import { LITEXML_APPLY_COMMAND, LITEXML_MODIFY_COMMAND } from '@lobehub/editor';
 import debug from 'debug';
 
@@ -20,6 +19,18 @@ import type {
 const log = debug('lobe:editor-runtime');
 
 /**
+ * Keep the runtime/editor contract minimal to avoid hard coupling to a specific
+ * @lobehub/editor package instance/version in downstream apps.
+ */
+type EditorFn = (...args: any[]) => any;
+
+interface EditorInstance {
+  dispatchCommand: EditorFn;
+  getDocument: EditorFn;
+  setDocument: EditorFn;
+}
+
+/**
  * Editor Execution Runtime
  * Handles the execution logic for editor operations including:
  * - Document initialization
@@ -29,7 +40,7 @@ const log = debug('lobe:editor-runtime');
  * - Text replacement
  */
 export class EditorRuntime {
-  private editor: IEditor | null = null;
+  private editor: EditorInstance | null = null;
   private titleSetter: ((title: string) => void) | null = null;
   private titleGetter: (() => string) | null = null;
   private currentDocId: string | undefined = undefined;
@@ -37,7 +48,7 @@ export class EditorRuntime {
   /**
    * Set the current editor instance
    */
-  setEditor(editor: IEditor | null) {
+  setEditor(editor: EditorInstance | null) {
     this.editor = editor;
   }
 
@@ -67,7 +78,7 @@ export class EditorRuntime {
   /**
    * Get the current editor instance
    */
-  private getEditor(): IEditor {
+  private getEditor(): EditorInstance {
     if (!this.editor) {
       throw new Error('Editor not initialized. Please set the editor instance first.');
     }
@@ -97,11 +108,24 @@ export class EditorRuntime {
     let extractedTitle: string | undefined;
 
     // Check if markdown starts with a # title heading
-    const titleMatch = /^#\s+(.+)(?:\r?\n|$)/.exec(markdown);
-    if (titleMatch) {
-      extractedTitle = titleMatch[1].trim();
+    const firstLineBreak = markdown.search(/\r?\n/);
+    const firstLineEnd = firstLineBreak === -1 ? markdown.length : firstLineBreak;
+    const firstLine = markdown.slice(0, firstLineEnd).replace(/\r$/, '');
+    const titleCandidate = firstLine.slice(1);
+    const isH1Title =
+      firstLine.startsWith('#') &&
+      (titleCandidate.startsWith(' ') || titleCandidate.startsWith('\t'));
+
+    if (isH1Title) {
+      extractedTitle = titleCandidate.trim();
+
       // Remove the title line from markdown
-      markdown = markdown.slice(titleMatch[0].length).trimStart();
+      if (firstLineBreak === -1) {
+        markdown = '';
+      } else {
+        const lineBreakLength = markdown[firstLineBreak] === '\r' ? 2 : 1;
+        markdown = markdown.slice(firstLineBreak + lineBreakLength).trimStart();
+      }
 
       // Set the title separately if title handlers are available
       if (this.titleSetter) {
@@ -531,8 +555,20 @@ export class EditorRuntime {
 
         // Build the updated LiteXML for this node
         // Extract attributes from the original fullMatch
-        const attrMatch = /<\w+\s+([^>]*)>/.exec(node.fullMatch);
-        const attributes = attrMatch ? attrMatch[1] : `id="${node.id}"`;
+        let attributes = `id="${node.id}"`;
+        const tagEnd = node.fullMatch.indexOf('>');
+
+        if (tagEnd > 0) {
+          const openingTag = node.fullMatch.slice(0, tagEnd);
+          const firstSpace = openingTag.indexOf(' ');
+
+          if (firstSpace > 0) {
+            const extractedAttributes = openingTag.slice(firstSpace + 1).trim();
+            if (extractedAttributes) {
+              attributes = extractedAttributes;
+            }
+          }
+        }
 
         const updatedLitexml = `<${node.tagName} ${attributes}>${newContent}</${node.tagName}>`;
         litexmlUpdates.push(updatedLitexml);

--- a/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
+++ b/packages/editor-runtime/src/__tests__/EditorRuntime.test.ts
@@ -35,9 +35,9 @@ describe('EditorRuntime', () => {
       expect(result.nodeCount).toBeGreaterThanOrEqual(0);
       expect(result.extractedTitle).toBeUndefined();
 
-      // Verify editor state - full text match (editor adds trailing space)
+      // Verify editor state
       const editorMarkdown = editor.getDocument('markdown') as unknown as string;
-      expect(editorMarkdown).toBe('Hello world\n\nThis is a paragraph. \n\n');
+      expect(editorMarkdown).toBe('Hello world\n\nThis is a paragraph.\n');
 
       // Verify XML structure
       const editorXml = editor.getDocument('litexml') as unknown as string;
@@ -54,9 +54,9 @@ describe('EditorRuntime', () => {
       expect(result.extractedTitle).toBe('My Document Title');
       expect(mockTitleSetter).toHaveBeenCalledWith('My Document Title');
 
-      // Verify editor state - only content without title (editor adds trailing space)
+      // Verify editor state - only content without title
       const editorMarkdown = editor.getDocument('markdown') as unknown as string;
-      expect(editorMarkdown).toBe('This is the content. \n\n');
+      expect(editorMarkdown).toBe('This is the content.\n');
     });
 
     it('should handle markdown with multiple headings', async () => {
@@ -68,10 +68,10 @@ describe('EditorRuntime', () => {
       // Verify title extraction (only first h1)
       expect(result.extractedTitle).toBe('Main Title');
 
-      // Verify editor state - content after title extraction (editor adds trailing space)
+      // Verify editor state - content after title extraction
       const editorMarkdown = editor.getDocument('markdown') as unknown as string;
       expect(editorMarkdown).toBe(
-        '## Section 1\n\nContent here. \n\n## Section 2\n\nMore content. \n\n',
+        '## Section 1\n\nContent here.\n\n## Section 2\n\nMore content.\n',
       );
     });
 

--- a/packages/editor-runtime/src/__tests__/__snapshots__/EditorRuntime.test.ts.snap
+++ b/packages/editor-runtime/src/__tests__/__snapshots__/EditorRuntime.test.ts.snap
@@ -5,10 +5,9 @@ exports[`EditorRuntime > modifyNodes > error handling > should normalize single 
 
 Single op
 
-First paragraph. 
+First paragraph.
 
-Second paragraph. 
-
+Second paragraph.
 "
 `;
 
@@ -21,10 +20,9 @@ Insert 2
 
 Insert 3
 
-First paragraph. 
+First paragraph.
 
-Second paragraph. 
-
+Second paragraph.
 "
 `;
 
@@ -33,10 +31,9 @@ exports[`EditorRuntime > modifyNodes > insert > should insert single node after 
 
 New inserted paragraph
 
-First paragraph. 
+First paragraph.
 
-Second paragraph. 
-
+Second paragraph.
 "
 `;
 
@@ -45,10 +42,9 @@ exports[`EditorRuntime > modifyNodes > mixed operations > should handle insert, 
 
 New content
 
-First paragraph. 
+First paragraph.
 
-Second paragraph. 
-
+Second paragraph.
 "
 `;
 
@@ -57,8 +53,7 @@ exports[`EditorRuntime > modifyNodes > modify > should modify existing node cont
 
 Modified content here
 
-Second paragraph. 
-
+Second paragraph.
 "
 `;
 
@@ -68,7 +63,6 @@ exports[`EditorRuntime > modifyNodes > modify > should modify multiple nodes at 
 Modified first
 
 Modified second
-
 "
 `;
 
@@ -86,48 +80,40 @@ exports[`EditorRuntime > modifyNodes > remove > should remove existing node 1`] 
 
 exports[`EditorRuntime > modifyNodes > remove > should remove multiple nodes 1`] = `
 "# Title
-
 "
 `;
 
 exports[`EditorRuntime > replaceText > should replace all occurrences by default 1`] = `
-"Hi world. This is a test. Hi again. Testing the world. 
-
+"Hi world. This is a test. Hi again. Testing the world.
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex first occurrence only 1`] = `
-"X world. This is a test. Hello again. Testing the world. 
-
+"X world. This is a test. Hello again. Testing the world.
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex patterns with optional groups 1`] = `
-"Hello world. This is a demo. Hello again. Testing the world. 
-
+"Hello world. This is a demo. Hello again. Testing the world.
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex with alternation 1`] = `
-"X X. This is a test. X again. Testing the X. 
-
+"X X. This is a test. X again. Testing the X.
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex with character classes 1`] = `
-"Guest and Guest are online. 
-
+"Guest and Guest are online.
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex with quantifiers 1`] = `
-"Hi world! Hi again! 
-
+"Hi world! Hi again!
 "
 `;
 
 exports[`EditorRuntime > replaceText > should support regex with word boundaries 1`] = `
-"Hello universe. This is a test. Hello again. Testing the universe. 
-
+"Hello universe. This is a test. Hello again. Testing the universe.
 "
 `;

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1648,6 +1648,42 @@ describe('google contextBuilders', () => {
         type: 'string',
       });
     });
+
+    it('should strip unsupported JSON Schema keywords for Google compatibility', () => {
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'A tool with unsupported schema keywords',
+          name: 'schemaTool',
+          parameters: {
+            properties: {
+              query: {
+                default: 'hello',
+                examples: ['hello', 'world'],
+                type: 'string',
+              },
+              nested: {
+                properties: {
+                  mode: {
+                    default: 'strict',
+                    examples: ['strict'],
+                    type: 'string',
+                  },
+                },
+                type: 'object',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool);
+      const properties = result.parameters?.properties as any;
+
+      expect(properties.query).toEqual({ type: 'string' });
+      expect(properties.nested.properties.mode).toEqual({ type: 'string' });
+    });
   });
 
   describe('buildGoogleTools', () => {
@@ -1733,6 +1769,57 @@ describe('google contextBuilders', () => {
       expect(googleTools![0].functionDeclarations).toHaveLength(2);
       expect(googleTools![0].functionDeclarations![0].name).toBe('get_weather');
       expect(googleTools![0].functionDeclarations![1].name).toBe('get_time');
+    });
+
+    it('[HOTFIX-P0] should deduplicate tools with the same function name', () => {
+      const tools: ChatCompletionTool[] = [
+        {
+          function: {
+            description: 'Search the web',
+            name: 'lobe-web-browsing____search____builtin',
+            parameters: {
+              properties: { query: { type: 'string' } },
+              required: ['query'],
+              type: 'object',
+            },
+          },
+          type: 'function',
+        },
+        {
+          function: {
+            description: 'Get weather',
+            name: 'get_weather',
+            parameters: {
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+              type: 'object',
+            },
+          },
+          type: 'function',
+        },
+        {
+          function: {
+            description: 'Search the web (duplicate)',
+            name: 'lobe-web-browsing____search____builtin',
+            parameters: {
+              properties: { query: { type: 'string' } },
+              required: ['query'],
+              type: 'object',
+            },
+          },
+          type: 'function',
+        },
+      ];
+
+      const googleTools = buildGoogleTools(tools);
+
+      expect(googleTools).toHaveLength(1);
+      expect(googleTools![0].functionDeclarations).toHaveLength(2);
+      expect(googleTools![0].functionDeclarations![0].name).toBe(
+        'lobe-web-browsing____search____builtin',
+      );
+      expect(googleTools![0].functionDeclarations![0].description).toBe('Search the web');
+      expect(googleTools![0].functionDeclarations![1].name).toBe('get_weather');
     });
   });
 });

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -150,6 +150,46 @@ describe('google contextBuilders', () => {
       });
     });
 
+    it('should convert gs:// PDF file parts for Vertex AI', async () => {
+      const content: UserMessageContentPart = {
+        file_url: {
+          id: 'file-1',
+          mimeType: 'application/pdf',
+          name: 'test.pdf',
+          size: 123,
+          url: 'gs://lobechat-cotti/vertex-native-pdf/chat-upload/hash/test.pdf',
+        },
+        type: 'file_url',
+      };
+
+      const result = await buildGooglePart(content, { isVertexAi: true });
+
+      expect(result).toEqual({
+        fileData: {
+          fileUri: 'gs://lobechat-cotti/vertex-native-pdf/chat-upload/hash/test.pdf',
+          mimeType: 'application/pdf',
+        },
+        thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
+      });
+    });
+
+    it('should ignore non-gs PDF file parts for Vertex AI fallback', async () => {
+      const content: UserMessageContentPart = {
+        file_url: {
+          id: 'file-1',
+          mimeType: 'application/pdf',
+          name: 'test.pdf',
+          size: 123,
+          url: 'https://example.com/test.pdf',
+        },
+        type: 'file_url',
+      };
+
+      const result = await buildGooglePart(content, { isVertexAi: true });
+
+      expect(result).toBeUndefined();
+    });
+
     it('should return undefined for unsupported SVG image (base64)', async () => {
       const svgBase64 =
         'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==';
@@ -244,6 +284,41 @@ describe('google contextBuilders', () => {
           { text: 'Check this image:', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE },
           {
             inlineData: { data: '...', mimeType: 'image/png' },
+            thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
+          },
+        ],
+        role: 'user',
+      });
+    });
+
+    it('should include Vertex PDF fileData parts in user messages', async () => {
+      const message: OpenAIChatMessage = {
+        content: [
+          { text: 'Read this PDF', type: 'text' },
+          {
+            file_url: {
+              id: 'file-1',
+              mimeType: 'application/pdf',
+              name: 'test.pdf',
+              size: 123,
+              url: 'gs://lobechat-cotti/vertex-native-pdf/chat-upload/hash/test.pdf',
+            },
+            type: 'file_url',
+          },
+        ],
+        role: 'user',
+      };
+
+      const converted = await buildGoogleMessage(message, undefined, { isVertexAi: true });
+
+      expect(converted).toEqual({
+        parts: [
+          { text: 'Read this PDF', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE },
+          {
+            fileData: {
+              fileUri: 'gs://lobechat-cotti/vertex-native-pdf/chat-upload/hash/test.pdf',
+              mimeType: 'application/pdf',
+            },
             thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
           },
         ],
@@ -913,7 +988,9 @@ describe('google contextBuilders', () => {
 
       expect(contents).toEqual([
         {
-          parts: [{ text: 'Need weather and time', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE }],
+          parts: [
+            { text: 'Need weather and time', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE },
+          ],
           role: 'user',
         },
         {
@@ -954,8 +1031,6 @@ describe('google contextBuilders', () => {
         },
       ]);
     });
-
-    
 
     it('[HOTFIX-P0] should merge three parallel tool responses into one user turn', async () => {
       const messages: OpenAIChatMessage[] = [
@@ -1138,7 +1213,9 @@ describe('google contextBuilders', () => {
 
       expect(contents).toEqual([
         {
-          parts: [{ text: 'Need weather and time', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE }],
+          parts: [
+            { text: 'Need weather and time', thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE },
+          ],
           role: 'user',
         },
         {

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -26,10 +26,13 @@ const isImageTypeSupported = (mimeType: string | null): boolean => {
 };
 
 /**
- * Magic thoughtSignature
- * @see https://ai.google.dev/gemini-api/docs/thought-signatures#model-behavior:~:text=context_engineering_is_the_way_to_go
+ * Magic thoughtSignature to bypass Gemini thought signature validation.
+ * Use `skip_thought_signature_validator` instead of `context_engineering_is_the_way_to_go`
+ * because Vertex AI only accepts `skip_thought_signature_validator`.
+ * @see https://ai.google.dev/gemini-api/docs/thought-signatures
+ * @see https://github.com/pydantic/pydantic-ai/issues/3881
  */
-export const GEMINI_MAGIC_THOUGHT_SIGNATURE = 'context_engineering_is_the_way_to_go';
+export const GEMINI_MAGIC_THOUGHT_SIGNATURE = 'skip_thought_signature_validator';
 
 /**
  * Convert OpenAI content part to Google Part format
@@ -251,6 +254,12 @@ export const buildGoogleMessages = async (
 };
 
 /**
+ * JSON Schema keywords that cause Google GenAI / Vertex AI SDK validation errors.
+ * Other unsupported keywords are silently ignored by the API, so only strip these.
+ */
+const UNSUPPORTED_SCHEMA_KEYS = new Set(['examples', 'default']);
+
+/**
  * Sanitize JSON Schema for Google GenAI compatibility
  * Google's API doesn't support certain JSON Schema keywords like 'const'
  * This function recursively processes the schema and converts unsupported keywords
@@ -266,6 +275,9 @@ const sanitizeSchemaForGoogle = (schema: Record<string, any>): Record<string, an
   const result: Record<string, any> = {};
 
   for (const [key, value] of Object.entries(schema)) {
+    // Strip unsupported JSON Schema keywords (e.g. examples, default, $schema)
+    if (UNSUPPORTED_SCHEMA_KEYS.has(key)) continue;
+
     // Convert 'const' to 'enum' with single value (Google doesn't support 'const')
     if (key === 'const') {
       result['enum'] = [value];
@@ -328,9 +340,19 @@ export const buildGoogleTools = (
 ): GoogleFunctionCallTool[] | undefined => {
   if (!tools || tools.length === 0) return;
 
+  // Deduplicate by function name to prevent Vertex AI 400 error:
+  // "Duplicate function declaration found: xxx"
+  const seenToolNames = new Set<string>();
+  const uniqueTools = tools.filter((tool) => {
+    const name = tool.function.name;
+    if (seenToolNames.has(name)) return false;
+    seenToolNames.add(name);
+    return true;
+  });
+
   return [
     {
-      functionDeclarations: tools.map((tool) => buildGoogleTool(tool)),
+      functionDeclarations: uniqueTools.map((tool) => buildGoogleTool(tool)),
     },
   ];
 };

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -36,6 +36,7 @@ export const GEMINI_MAGIC_THOUGHT_SIGNATURE = 'context_engineering_is_the_way_to
  */
 export const buildGooglePart = async (
   content: UserMessageContentPart,
+  options: { isVertexAi?: boolean } = {},
 ): Promise<Part | undefined> => {
   switch (content.type) {
     default: {
@@ -106,6 +107,22 @@ export const buildGooglePart = async (
 
       throw new TypeError(`currently we don't support video url: ${content.video_url.url}`);
     }
+
+    case 'file_url': {
+      if (!options.isVertexAi) return undefined;
+
+      const { mimeType, url } = content.file_url;
+
+      if (!url?.startsWith('gs://')) return undefined;
+
+      return {
+        fileData: {
+          fileUri: url,
+          mimeType: mimeType || 'application/octet-stream',
+        },
+        thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE,
+      };
+    }
   }
 };
 
@@ -115,6 +132,7 @@ export const buildGooglePart = async (
 export const buildGoogleMessage = async (
   message: OpenAIChatMessage,
   toolCallNameMap?: Map<string, string>,
+  options: { isVertexAi?: boolean } = {},
 ): Promise<Content> => {
   const content = message.content as string | UserMessageContentPart[];
 
@@ -154,7 +172,7 @@ export const buildGoogleMessage = async (
     if (typeof content === 'string')
       return [{ text: content, thoughtSignature: GEMINI_MAGIC_THOUGHT_SIGNATURE }];
 
-    const parts = await Promise.all(content.map(async (c) => await buildGooglePart(c)));
+    const parts = await Promise.all(content.map(async (c) => await buildGooglePart(c, options)));
     return parts.filter(Boolean) as Part[];
   };
 
@@ -167,7 +185,10 @@ export const buildGoogleMessage = async (
 /**
  * Convert messages from the OpenAI format to Google GenAI SDK format
  */
-export const buildGoogleMessages = async (messages: OpenAIChatMessage[]): Promise<Content[]> => {
+export const buildGoogleMessages = async (
+  messages: OpenAIChatMessage[],
+  options: { isVertexAi?: boolean } = {},
+): Promise<Content[]> => {
   const toolCallNameMap = new Map<string, string>();
 
   // Build tool call id to name mapping
@@ -183,7 +204,7 @@ export const buildGoogleMessages = async (messages: OpenAIChatMessage[]): Promis
 
   const pools = messages
     .filter((message) => message.role !== 'function')
-    .map(async (msg) => await buildGoogleMessage(msg, toolCallNameMap));
+    .map(async (msg) => await buildGoogleMessage(msg, toolCallNameMap, options));
 
   const contents = await Promise.all(pools);
 
@@ -292,7 +313,7 @@ export const buildGoogleTool = (tool: ChatCompletionTool): FunctionDeclaration =
     name: functionDeclaration.name,
     parameters: {
       description: parameters?.description,
-      properties: properties,
+      properties,
       required: parameters?.required,
       type: SchemaType.OBJECT,
     },

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -73,7 +73,7 @@ describe('LobeGoogleAI', () => {
     });
 
     it('should withGrounding', () => {
-      const data = [
+      const _data = [
         {
           candidates: [{ content: { parts: [{ text: 'As' }], role: 'model' } }],
           usageMetadata: { promptTokenCount: 8, totalTokenCount: 8 },
@@ -440,10 +440,10 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
 
         // Read first value then cancel to trigger error chunk
-        chunks.push((await reader.read()).value);
+        const firstChunk = (await reader.read()).value;
+        const chunks: any[] = [firstChunk];
         abortController.abort();
 
         // Read all remaining chunks
@@ -494,10 +494,10 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
 
         // Read first value then collect remaining chunks (error included)
-        chunks.push((await reader.read()).value);
+        const firstChunk = (await reader.read()).value;
+        const chunks: any[] = [firstChunk];
         let result;
         while (!(result = await reader.read()).done) {
           chunks.push(result.value);
@@ -518,9 +518,15 @@ describe('LobeGoogleAI', () => {
       });
 
       it('should handle AbortError without data', async () => {
-        const mockStream = (async function* () {
-          throw new Error('aborted');
-        })();
+        const mockStream: AsyncIterable<any> = {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                throw new Error('aborted');
+              },
+            };
+          },
+        };
 
         const abortController = new AbortController();
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
@@ -559,10 +565,10 @@ describe('LobeGoogleAI', () => {
         const enhancedStream = instance['createEnhancedStream'](mockStream, abortController.signal);
 
         const reader = enhancedStream.getReader();
-        const chunks: any[] = [];
 
         // Read first value then collect remaining chunks (parsing error)
-        chunks.push((await reader.read()).value);
+        const firstChunk = (await reader.read()).value;
+        const chunks: any[] = [firstChunk];
         let result;
         while (!(result = await reader.read()).done) {
           chunks.push(result.value);
@@ -617,7 +623,7 @@ describe('thinkingConfig includeThoughts logic', () => {
     expect(config.thinkingConfig?.includeThoughts).toBe(true);
   });
 
-  it('should enable thinking for gemini-3-pro-image models', async () => {
+  it('should not force includeThoughts for gemini-3-pro-image models by default', async () => {
     const mockStreamData = (async function* (): AsyncGenerator<GenerateContentResponse> {})();
     vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(mockStreamData);
 
@@ -629,7 +635,7 @@ describe('thinkingConfig includeThoughts logic', () => {
 
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
     const config = callArgs[0].config;
-    expect(config.thinkingConfig?.includeThoughts).toBe(true);
+    expect(config.thinkingConfig?.includeThoughts).toBeUndefined();
   });
 
   it('should enable thinking for thinking-enabled models', async () => {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -149,7 +149,9 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         thinkingLevel,
       }) as ThinkingConfig;
 
-      const contents = await buildGoogleMessages(payload.messages);
+      const contents = await buildGoogleMessages(payload.messages, {
+        isVertexAi: this.isVertexAi,
+      });
 
       const controller = new AbortController();
       const originalSignal = options?.signal;
@@ -285,7 +287,9 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    */
   async generateObject(payload: GenerateObjectPayload, options?: GenerateObjectOptions) {
     // Convert OpenAI messages to Google format
-    const contents = await buildGoogleMessages(payload.messages);
+    const contents = await buildGoogleMessages(payload.messages, {
+      isVertexAi: this.isVertexAi,
+    });
 
     // Handle tools-based structured output
     if (payload.tools && payload.tools.length > 0) {

--- a/packages/model-runtime/src/providers/google/thinkingResolver.test.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.test.ts
@@ -238,13 +238,15 @@ describe('thinkingResolver', () => {
     describe('gemini-3-pro-preview (the original issue model)', () => {
       const model = 'gemini-3-pro-preview';
 
-      it('should not set thinkingBudget by default for Gemini 3 (let API decide)', () => {
+      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
         // For Gemini 3 models, when neither thinkingLevel nor thinkingBudget is set,
-        // don't set any thinking params - let API use its default behavior
+        // don't set any thinking params - let API use its default behavior.
+        // includeThoughts must be undefined to avoid Vertex AI error:
+        // "include_thoughts is only enabled when thinking is enabled"
         expect(result).toEqual({
-          includeThoughts: true,
+          includeThoughts: undefined,
           thinkingBudget: undefined,
         });
       });
@@ -274,12 +276,12 @@ describe('thinkingResolver', () => {
     describe('gemini-3-pro-image-preview (thinking-enabled model)', () => {
       const model = 'gemini-3-pro-image-preview';
 
-      it('should not set thinkingBudget by default for Gemini 3 (let API decide)', () => {
+      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
         // For Gemini 3 models, don't set thinkingBudget by default
         expect(result).toEqual({
-          includeThoughts: true,
+          includeThoughts: undefined,
           thinkingBudget: undefined,
         });
       });
@@ -349,12 +351,12 @@ describe('thinkingResolver', () => {
     describe('gemini-3-flash (supports thinking and thinkingLevel)', () => {
       const model = 'gemini-3-flash';
 
-      it('should not set thinkingBudget by default for Gemini 3 (let API decide)', () => {
+      it('should not set thinkingBudget or includeThoughts by default for Gemini 3 (let API decide)', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
         // For Gemini 3 models, don't set thinkingBudget by default
         expect(result).toEqual({
-          includeThoughts: true,
+          includeThoughts: undefined,
           thinkingBudget: undefined,
         });
       });
@@ -404,16 +406,29 @@ describe('thinkingResolver', () => {
 
         expect(result.includeThoughts).toBeUndefined();
       });
+
+      it('should not enable includeThoughts when thinkingLevel is set but budget defaults to 0', () => {
+        // flash-lite ignores thinkingLevel (not Gemini 3) and defaults to budget=0.
+        // Must not emit includeThoughts:true with thinkingBudget:0 — Vertex AI rejects this.
+        const result = resolveGoogleThinkingConfig(model, { thinkingLevel: 'high' });
+
+        expect(result).toEqual({
+          includeThoughts: undefined,
+          thinkingBudget: 0,
+        });
+      });
     });
 
     describe('nano-banana-pro-preview (thinking-enabled model)', () => {
       const model = 'nano-banana-pro-preview';
 
-      it('should enable includeThoughts by default', () => {
+      it('should not enable includeThoughts when thinkingBudget is undefined', () => {
         const result = resolveGoogleThinkingConfig(model, {});
 
-        // nano-banana-pro is 'other' category, so thinkingBudget is undefined
-        expect(result.includeThoughts).toBe(true);
+        // nano-banana-pro is 'other' category, so thinkingBudget is undefined.
+        // Without an actual thinking budget or level, includeThoughts should not be set
+        // to avoid Vertex AI error.
+        expect(result.includeThoughts).toBeUndefined();
       });
     });
   });

--- a/packages/model-runtime/src/providers/google/thinkingResolver.ts
+++ b/packages/model-runtime/src/providers/google/thinkingResolver.ts
@@ -218,7 +218,10 @@ export const resolveGoogleThinkingBudget = (
 };
 
 /**
- * Determines if includeThoughts should be enabled
+ * Determines if includeThoughts should be enabled.
+ *
+ * Vertex AI rejects includeThoughts:true when thinking is not actually
+ * enabled, so we must only return true when thinking is genuinely active.
  */
 const shouldIncludeThoughts = (
   model: string,
@@ -227,19 +230,15 @@ const shouldIncludeThoughts = (
 ): boolean | undefined => {
   const { thinkingBudget, thinkingLevel } = options;
 
-  // Conditions that enable thinking:
-  // 1. thinkingBudget is explicitly set (and not 0)
-  // 2. thinkingLevel is explicitly set
-  // 3. Model is in the thinking-enabled list
-  const hasExplicitThinking = !!thinkingBudget || !!thinkingLevel;
-  const isThinkingModel = isThinkingEnabledModel(model);
+  // 1. No thinking signal at all → not applicable
+  if (!thinkingBudget && !thinkingLevel && !isThinkingEnabledModel(model)) return undefined;
 
-  // If thinking is requested AND budget is not 0, enable includeThoughts
-  if ((hasExplicitThinking || isThinkingModel) && resolvedBudget !== 0) {
-    return true;
-  }
+  // 2. Budget resolved to a number → active only when non-zero
+  if (typeof resolvedBudget === 'number') return resolvedBudget !== 0 ? true : undefined;
 
-  return undefined;
+  // 3. Budget is undefined (Gemini 3 default / "other" category) →
+  //    only thinkingLevel can activate thinking without a numeric budget
+  return thinkingLevel ? true : undefined;
 };
 
 /**

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -33,6 +33,17 @@ interface UserMessageContentPartImage {
   type: 'image_url';
 }
 
+interface UserMessageContentPartFile {
+  file_url: {
+    id?: string;
+    mimeType?: string;
+    name?: string;
+    size?: number;
+    url: string;
+  };
+  type: 'file_url';
+}
+
 interface UserMessageContentPartVideo {
   type: 'video_url';
   video_url: { url: string };
@@ -41,6 +52,7 @@ interface UserMessageContentPartVideo {
 export type UserMessageContentPart =
   | UserMessageContentPartText
   | UserMessageContentPartImage
+  | UserMessageContentPartFile
   | UserMessageContentPartVideo
   | UserMessageContentPartThinking;
 

--- a/packages/prompts/src/prompts/knowledgeBaseQA/formatFileContents.ts
+++ b/packages/prompts/src/prompts/knowledgeBaseQA/formatFileContents.ts
@@ -3,6 +3,9 @@ export interface FileContent {
   error?: string;
   fileId: string;
   filename: string;
+  fileType?: string;
+  size?: number;
+  url?: string;
 }
 
 /**

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -34,7 +34,21 @@ interface UserMessageContentPartImage {
   type: 'image_url';
 }
 
-export type UserMessageContentPart = UserMessageContentPartText | UserMessageContentPartImage;
+interface UserMessageContentPartFile {
+  file_url: {
+    id?: string;
+    mimeType?: string;
+    name?: string;
+    size?: number;
+    url: string;
+  };
+  type: 'file_url';
+}
+
+export type UserMessageContentPart =
+  | UserMessageContentPartText
+  | UserMessageContentPartImage
+  | UserMessageContentPartFile;
 
 export interface OpenAIChatMessage {
   /**

--- a/scripts/checkCustomHotfixes.mts
+++ b/scripts/checkCustomHotfixes.mts
@@ -30,11 +30,38 @@ const checks: HotfixCheck[] = [
     ],
   },
   {
+    file: 'packages/model-runtime/src/core/contextBuilders/google.ts',
+    name: 'Google tool declaration dedupe guard',
+    needles: ['const seenToolNames = new Set<string>();', 'functionDeclarations: uniqueTools.map'],
+  },
+  {
+    file: 'packages/model-runtime/src/core/contextBuilders/google.ts',
+    name: 'Google schema sanitizer guard',
+    needles: [
+      "const UNSUPPORTED_SCHEMA_KEYS = new Set(['examples', 'default']);",
+      'if (UNSUPPORTED_SCHEMA_KEYS.has(key)) continue;',
+    ],
+  },
+  {
     file: 'packages/model-runtime/src/core/contextBuilders/google.test.ts',
     name: 'Parallel tool response regression test',
     // Auto-growing: require the presence of HOTFIX-P0 regression titles.
     needles: [HOTFIX_REGRESSION_TITLE],
     minMatches: 3,
+  },
+  {
+    file: 'packages/model-runtime/src/providers/google/thinkingResolver.ts',
+    name: 'Google includeThoughts safety guard',
+    needles: [
+      'if (!thinkingBudget && !thinkingLevel && !isThinkingEnabledModel(model)) return undefined;',
+      "if (typeof resolvedBudget === 'number') return resolvedBudget !== 0 ? true : undefined;",
+      'return thinkingLevel ? true : undefined;',
+    ],
+  },
+  {
+    file: 'packages/model-runtime/src/providers/google/thinkingResolver.test.ts',
+    name: 'Google includeThoughts regression test',
+    needles: ['should not enable includeThoughts when thinkingLevel is set but budget defaults to 0'],
   },
   {
     file: 'packages/model-runtime/src/_custom/mergeGoogleFunctionResponses.test.ts',

--- a/src/_custom/CHANGELOG.md
+++ b/src/_custom/CHANGELOG.md
@@ -14,6 +14,16 @@
 - 回滚：移除 `buildGoogleTools` 去重逻辑、对应测试与 `checkCustomHotfixes` 中的 dedupe guard 检查
 - 影响：仅影响 Google/Vertex 的 tool 声明构建；无重复函数名时行为不变
 
+### \[2026-03-09] 修复模型别名描述与 thinkingLevel3 默认值的回归风险
+
+- 类型: custom
+- 涉及文件: src/\_custom/registry/modelCustomization.ts; src/\_custom/registry/modelCustomization.test.ts; src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx; src/services/chat/mecha/modelParamsResolver.ts; src/services/chat/mecha/modelParamsResolver.test.ts
+- 原因：模型详情描述优先使用 runtime description 会覆盖本地化文案；`thinkingLevel3` 默认值在混合扩展参数场景下会覆盖用户已设置的 `thinkingLevel`
+- 方案：`resolveModelDetailDescription` 改为 “有本地化文案则优先本地化，无本地化才回退 runtime description”；`resolveModelExtendParams` 改为仅在未设置其他 thinkingLevel 时才应用 `thinkingLevel3` 默认值，且显式 `thinkingLevel3` 仍优先
+- 验证：`bunx vitest run --silent='passed-only' 'src/_custom/registry/modelCustomization.test.ts'` 通过；`bunx vitest run --silent='passed-only' 'src/services/chat/mecha/modelParamsResolver.test.ts'` 通过
+- 回滚：恢复 `resolveModelDetailDescription` 直接优先 `modelDescription`，并恢复 `thinkingLevel3` 分支无条件写默认值逻辑
+- 影响：仅影响模型详情描述展示优先级与 thinkingLevel 参数合并策略；不改变单一 `thinkingLevel3` 模型的默认 `low` 行为
+
 ### \[2026-03-09] 默认 inbox agent 新话题时清空 “关联文件” 勾选
 
 - 类型: custom

--- a/src/_custom/CHANGELOG.md
+++ b/src/_custom/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ---
 
+### \[2026-03-09] 对齐上游 Vertex 400 修复：去重重复 function declaration
+
+- 类型: custom
+- 涉及文件: packages/model-runtime/src/core/contextBuilders/google.ts; packages/model-runtime/src/core/contextBuilders/google.test.ts; packages/model-runtime/src/providers/google/thinkingResolver.ts; packages/model-runtime/src/providers/google/thinkingResolver.test.ts; packages/model-runtime/src/providers/google/index.test.ts; scripts/checkCustomHotfixes.mts
+- 原因：合并上游稳定版时发现当前分支缺少 PR #12604 的关键修复，`buildGoogleTools` 会原样透传重复函数声明，可能触发 Vertex `400 Duplicate function declaration found`
+- 方案：按上游实现在 `buildGoogleTools` 内按 `tool.function.name` 去重，并将 Google `thoughtSignature` 回退到 `skip_thought_signature_validator`；同时补回 `UNSUPPORTED_SCHEMA_KEYS` 过滤（`examples/default`）与 `thinkingResolver` 中 `includeThoughts` 安全判断（避免未启用 thinking 时仍传 `includeThoughts: true`）；补充 `[HOTFIX-P0]` 回归用例覆盖重复函数名场景；热修复门禁脚本新增相关检查
+- 验证：`cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/contextBuilders/google.test.ts'` 通过；`cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/_custom/mergeGoogleFunctionResponses.test.ts'` 通过；`cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/thinkingResolver.test.ts'` 通过；`cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/index.test.ts'` 通过；`bun run custom:verify-hotfixes` 通过
+- 回滚：移除 `buildGoogleTools` 去重逻辑、对应测试与 `checkCustomHotfixes` 中的 dedupe guard 检查
+- 影响：仅影响 Google/Vertex 的 tool 声明构建；无重复函数名时行为不变
+
 ### \[2026-03-09] 默认 inbox agent 新话题时清空 “关联文件” 勾选
 
 - 类型: custom

--- a/src/_custom/CHANGELOG.md
+++ b/src/_custom/CHANGELOG.md
@@ -4,10 +4,83 @@
 
 ---
 
-### [2026-02-16] Docker 构建 type-check 修复（slash/menu key 与 OTel 类型）
+### \[2026-03-09] Vertex 当前聊天上传 PDF 原生输入接线（v1）
 
 - 类型: custom
-- 涉及文件: src/app/[variants]/(main)/agent/profile/features/EditorCanvas/useSlashItems.tsx; src/features/ChatInput/InputEditor/useSlashItems.tsx; src/features/PageEditor/EditorCanvas/useSlashItems.tsx; src/features/Conversation/Messages/Assistant/Actions/index.tsx; src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx; src/features/Conversation/Messages/Supervisor/Actions/index.tsx; src/features/Conversation/Messages/Task/Actions/index.tsx; src/features/Conversation/Messages/User/Actions/index.tsx; packages/observability-otel/src/node.ts
+- 涉及文件: src/\_custom/services/vertexNativePdf.ts; src/app/(backend)/webapi/chat/\[provider]/route.ts; packages/context-engine/src/processors/MessageContent.ts; packages/context-engine/src/processors/**tests**/MessageContent.test.ts; packages/model-runtime/src/types/chat.ts; packages/model-runtime/src/core/contextBuilders/google.ts; packages/model-runtime/src/core/contextBuilders/google.test.ts; packages/model-runtime/src/providers/google/index.ts; packages/types/src/openai/chat.ts
+- 原因：v1 决定只覆盖 “当前聊天上传 PDF” 路径，需要在不改 Agent 关联文件 / 知识库流程的前提下，为 Vertex 增加原生 PDF `fileData` 输入，并保留现有文本解析注入作为 fallback
+- 方案：聊天上下文工程阶段仅对 `vertexai + application/pdf` 追加 `file_url` content part，继续保留原有 `<file>...</file>` 文本注入；服务端 `/webapi/chat/[provider]` 在进入 model-runtime 前对这些 PDF part 按需同步到 GCS 并改写成 `gs://...`；Google/Vertex context builder 仅在 `vertexai` 且 URI 为 `gs://` 时生成 `Part.fileData`
+- 验证：`cd packages/context-engine && bunx vitest run --silent='passed-only' 'src/processors/__tests__/MessageContent.test.ts'` 通过；`cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/core/contextBuilders/google.test.ts'` 通过；`bunx tsx src/_custom/vertexPdfNativePoc.ts` 仍返回 `123` 且 `promptTokensDetails` 含 `DOCUMENT`
+- 回滚：删除 `src/_custom/services/vertexNativePdf.ts` 与 `/webapi/chat/[provider]` 注入；移除 `file_url` schema 扩展与 `MessageContentProcessor` / `google` builder 对应分支
+- 影响：仅对 Vertex 当前聊天上传的 PDF 增加原生输入尝试；若 GCS 同步失败会退回现有文本注入；Agent 关联文件、知识库检索路径保持不变
+
+### \[2026-03-09] Vertex native PDF 成功后移除误导性的空文本 `<file>` 注入
+
+- 类型: custom
+- 涉及文件: src/\_custom/services/vertexNativePdf.ts; src/\_custom/services/vertexNativePdf.test.ts
+- 原因：页面实测发现扫描版 PDF 虽已通过 Vertex native `fileData` 能力可被正确识别，但聊天链路仍同时注入旧的 `<file ...></file>` 文本 fallback。对无文本层 PDF，这段 fallback 会把 “提取内容为空” 显式暴露给模型，导致回答错误地退回 “无法分析附件”
+- 方案：在 `/webapi/chat/[provider]` 的 `prepareVertexNativePdfMessages(...)` 中，仅当 native PDF part 成功转换为 `gs://` 时，移除同条消息里对应 PDF 的文本 `<file>` fallback；若 native 准备失败，则继续保留旧 fallback
+- 验证：`bunx vitest run --silent='passed-only' 'src/_custom/services/vertexNativePdf.test.ts'` 通过；使用根目录 `增值电信业务经营许可证-正文及附页-20250418.pdf` 运行 `bunx tsx src/_custom/vertexPdfNativePoc.ts --file ... --prompt '帮我分析附件内容和实际的边框样式情况。请直接基于PDF视觉内容回答。'`，`gemini-2.5-flash` 已正确识别许可证正文与边框花纹，且 `usageMetadata.promptTokensDetails` 含 `DOCUMENT`
+- 回滚：删除 `stripNativePdfFallbackPrompt(...)` 清理逻辑与对应测试
+- 影响：仅在 Vertex native PDF 成功生效时清掉误导性的空文本 fallback；不改变 native 失败时的兼容行为
+
+### \[2026-03-09] Vertex Agent 关联文件 PDF 复用原生输入链路
+
+- 类型: custom
+- 涉及文件: src/services/chat/mecha/contextEngineering.ts; packages/context-engine/src/providers/KnowledgeInjector.ts; packages/context-engine/src/engine/messages/MessagesEngine.ts; packages/context-engine/src/providers/**tests**/KnowledgeInjector.test.ts; src/\_custom/services/vertexNativePdf.ts; src/\_custom/services/vertexNativePdf.test.ts; packages/prompts/src/prompts/knowledgeBaseQA/formatFileContents.ts
+- 原因：用户侧会把 “当前聊天上传 PDF” 和 “勾选关联文件中的 PDF” 视为同一能力，但现状只有前者会进入 Vertex native `fileData` 链路；Agent 关联文件仍只有文本注入，扫描件 / 无文本层 PDF 体感上等于未生效
+- 方案：上下文工程阶段为已启用的 Agent 关联 PDF 保留 `url/type/size` 元数据；`KnowledgeInjector` 在 `vertexai` 下除了原有文本知识注入外，额外向 system injection message 追加 `file_url` part；服务端继续复用既有 GCS 改写与 native fallback 清理逻辑
+- 验证：补充 `KnowledgeInjector` 与 `vertexNativePdf` 单测，验证关联 PDF 会生成 `file_url` part，且 native 成功后可清理关联文件 XML fallback
+- 回滚：移除 `KnowledgeInjector` 中的 `file_url` 追加逻辑，并恢复 `contextEngineering` 对 agent files 的旧过滤条件
+- 影响：仅对 Vertex 下 Agent 关联文件中的 PDF 增加原生输入尝试；知识库检索与非 PDF 文件保持原行为
+
+### \[2026-03-09] Docker 运行层补齐 @napi-rs/canvas optional native package 暴露
+
+- 涉及文件: Dockerfile
+- 原因：页面实测上传 PDF 时，运行容器仍报 `DOMMatrix is not defined`。进一步确认 `@napi-rs/canvas` 主包已在 `/app/node_modules/@napi-rs/canvas`，但与其版本匹配的 optional native package `@napi-rs/canvas-linux-x64-gnu` 没有暴露到 `/app/node_modules/@napi-rs/`，导致 Node 解析 `require('@napi-rs/canvas-linux-x64-gnu')` 失败
+- 方案：在 Docker app stage 不再遍历目录名猜测链接，而是读取顶层 `@napi-rs/canvas/package.json` 的 `optionalDependencies`，按声明版本为每个 `@napi-rs/canvas-*` 平台包建立符号链接
+- 影响：修复 Docker 部署环境下 `pdfjs-dist` 对 `DOMMatrix` polyfill 的 native binding 解析，恢复 PDF 解析链路
+
+---
+
+### \[2026-03-09] Vertex 原生 PDF 输入 PoC（独立脚本验证）
+
+- 类型: custom
+- 涉及文件: src/\_custom/vertexPdfNativePoc.ts; src/\_custom/CHANGELOG.md
+- 原因：在接入主流程前，需要先确认当前 Vertex 配置 + `gs://lobechat-cotti` 能否通过 `@google/genai` 的原生 `fileData` 路径稳定读取 PDF，而不是继续依赖现有文本解析注入
+- 方案：新增独立脚本 `src/_custom/vertexPdfNativePoc.ts`，按 `.env` 读取 `VERTEXAI_CREDENTIALS` / `VERTEXAI_PROJECT` / `VERTEXAI_LOCATION`，将本地 PDF 上传或复用到 GCS，再以 `vertexai: true` + PDF `fileData.fileUri=gs://...` 发起一次 `generateContent`
+- 验证：2026-03-09 本地执行 `bunx tsx src/_custom/vertexPdfNativePoc.ts`，使用仓库测试文件 `packages/file-loaders/test/fixtures/test.pdf` 上传到 `gs://lobechat-cotti/vertex-pdf-poc/67e85b9398030030-test.pdf`；`gemini-2.5-flash` 返回 `123`，脚本输出 `Verification: PASS`，且 `usageMetadata.promptTokensDetails` 中出现 `DOCUMENT` token 计数
+- 回滚：删除 `src/_custom/vertexPdfNativePoc.ts` 与本条记录
+- 影响：仅新增 Phase 1 验证工具，不改聊天上传、Agent 关联文件、知识库或 `packages/model-runtime` 主流程
+
+---
+
+### \[2026-03-09] Docker 运行镜像补齐 @napi-rs/canvas 平台绑定
+
+- 类型: custom
+- 涉及文件: Dockerfile; src/store/file/slices/chat/action.ts; src/store/file/slices/chat/action.test.ts
+- 原因：聊天上传 PDF 后，`document.parseFileContent` 在容器内失败，日志显示 `DOMMatrix is not defined`。进一步定位为运行镜像中的 `@napi-rs/canvas` 顶层包存在，但其 optional native binding `@napi-rs/canvas-linux-x64-gnu` 未暴露到 Node 可解析路径，导致 `pdfjs-dist` 的 DOMMatrix polyfill 失效
+- 方案：在 Docker app stage 为 `.pnpm` 中的 `@napi-rs/canvas-*` 平台包建立到 `/app/node_modules/@napi-rs/` 的符号链接，确保 `require('@napi-rs/canvas')` 可加载 native binding；聊天侧继续保留 `parseFileContent` 完成前阻塞发送的修复，避免只有 URL 无正文的竞态
+- 回滚：删除 Dockerfile 中新增的 `@napi-rs/canvas-*` 链接逻辑，并回退聊天文件上传状态流转改动
+- 影响：修复 Docker 部署环境下的 PDF 解析能力；仅影响文件解析与聊天附件注入时序，不改变其他业务流程
+
+---
+
+### \[2026-02-22] Gemini 3.1 别名描述与默认思考等级（注入式改造）
+
+- 类型: custom
+- 涉及文件: src/\_custom/registry/modelCustomization.ts; src/store/aiInfra/slices/aiProvider/action.ts; src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx; src/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider.tsx; src/services/chat/mecha/modelParamsResolver.ts; src/app/\[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx; src/store/aiInfra/slices/aiProvider/**tests**/action.test.ts; src/services/chat/mecha/modelParamsResolver.test.ts
+- 原因：`gemini-3.1-pro-preview` 在重命名为 `Cotti-Pro` 后，模型详情描述仍显示官方名（含 `Gemini 3 Pro` / `Gemini 3 Flash` 变体）；且 `thinkingLevel3` 期望默认 `low`
+- 方案：将别名描述替换与 thinkingLevel3 默认值逻辑收敛到 `src/_custom/registry/modelCustomization.ts`；上游文件仅做 import + 调用注入。`ModelDetailPanel` 优先使用运行时模型描述（支持别名替换），并新增 `NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE` 开关（默认开启，`0` 可关闭扩展替换）
+- 回滚：移除上述注入 import/call，并删除 `modelCustomization.ts`
+- 影响：仅影响模型展示文案与 Gemini 3.1 的默认思考等级，不改变其他模型能力
+
+---
+
+### \[2026-02-16] Docker 构建 type-check 修复（slash/menu key 与 OTel 类型）
+
+- 类型: custom
+- 涉及文件: src/app/\[variants]/(main)/agent/profile/features/EditorCanvas/useSlashItems.tsx; src/features/ChatInput/InputEditor/useSlashItems.tsx; src/features/PageEditor/EditorCanvas/useSlashItems.tsx; src/features/Conversation/Messages/Assistant/Actions/index.tsx; src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx; src/features/Conversation/Messages/Supervisor/Actions/index.tsx; src/features/Conversation/Messages/Task/Actions/index.tsx; src/features/Conversation/Messages/User/Actions/index.tsx; packages/observability-otel/src/node.ts
 - 原因：Docker build 阶段 tsgo 因 symbol key 拼接与 `@opentelemetry/auto-instrumentations-node` 类型解析失败而中断
 - 方案：slash items 展示 key 使用 `String()` 显式转换；Actions 子项 key 拼接统一 `String()`；在 OTel import 上添加 `@ts-expect-error` 以避免 Docker 构建中 tsgo 解析失败
 - 回滚：恢复 key 直接使用并移除 `@ts-expect-error`
@@ -15,10 +88,10 @@
 
 ---
 
-### [2026-02-10] 公开仓库安全门禁（方案 B）
+### \[2026-02-10] 公开仓库安全门禁（方案 B）
 
 - 类型: custom
-- 涉及文件: .github/workflows/public-security-gate.yml; scripts/checkPublicRepoSafety.mts; package.json; .env.desktop; src/_custom/routes/dev-login.ts; src/_custom/SECONDARY_DEV_GUIDE.md
+- 涉及文件: .github/workflows/public-security-gate.yml; scripts/checkPublicRepoSafety.mts; package.json; .env.desktop; src/\_custom/routes/dev-login.ts; src/\_custom/SECONDARY_DEV_GUIDE.md
 - 原因：仓库公开后需要降低凭据误提交与 dev bypass 配置误放开的风险
 - 方案：新增 `custom:verify-public-safety` 与 `Public Security Gate` workflow；将 `.env.desktop` 脱敏；`/api/dev/login` 默认仅接受请求头 token，关闭 query token（需显式开启 `DEV_AUTH_BYPASS_ALLOW_QUERY_TOKEN=1`）
 - 回滚：删除 public-security-gate workflow 与校验脚本，恢复 `.env.desktop` 与 dev-login token 读取逻辑
@@ -26,10 +99,10 @@
 
 ---
 
-### [2026-02-09] Google/Vertex 400 Hotfix 回归门禁（P0 自动增长）
+### \[2026-02-09] Google/Vertex 400 Hotfix 回归门禁（P0 自动增长）
 
 - 类型: custom
-- 涉及文件: .github/workflows/custom-hotfix-gate.yml; scripts/checkCustomHotfixes.mts; package.json; packages/model-runtime/src/core/contextBuilders/google.test.ts; packages/model-runtime/src/_custom/mergeGoogleFunctionResponses.test.ts; src/_custom/SECONDARY_DEV_GUIDE.md
+- 涉及文件: .github/workflows/custom-hotfix-gate.yml; scripts/checkCustomHotfixes.mts; package.json; packages/model-runtime/src/core/contextBuilders/google.test.ts; packages/model-runtime/src/\_custom/mergeGoogleFunctionResponses.test.ts; src/\_custom/SECONDARY_DEV_GUIDE.md
 - 原因：upstream-sync/dev 合并到 main 时，关键 400 hotfix 容易被冲掉或行为回归，需要强制门禁与快速定位
 - 方案：新增 `Custom Hotfix Gate` 工作流，仅对 `upstream-sync -> main` 与 `dev -> main` PR 强制执行；失败输出 `Hotfix Regression Failed`；P0 回归用例采用 `[HOTFIX-P0]` 前缀并由脚本自动识别，实现守卫自动增长
 - 回滚：删除 `custom-hotfix-gate.yml` 与新增脚本命令，并移除测试标题前缀与脚本前缀扫描逻辑
@@ -37,10 +110,10 @@
 
 ---
 
-### [2026-02-09] 支持通过环境变量自定义浏览器 Tab 品牌名称
+### \[2026-02-09] 支持通过环境变量自定义浏览器 Tab 品牌名称
 
 - 类型: custom
-- 涉及文件: src/components/PageTitle/index.tsx; src/app/[variants]/metadata.ts
+- 涉及文件: src/components/PageTitle/index.tsx; src/app/\[variants]/metadata.ts
 - 原因：默认 Tab 标题使用 business const 中的 BRANDING_NAME（OneAI），与部署环境中的 `NEXT_PUBLIC_BRAND_NAME` 不一致
 - 方案：标题计算优先读取 `getBrandName()`（来自 `NEXT_PUBLIC_BRAND_NAME`），为空时回退到 BRANDING_NAME
 - 回滚：移除 `@/_custom/registry/branding` 注入并恢复 BRANDING_NAME 直读
@@ -48,21 +121,21 @@
 
 ---
 
-### [2026-02-09] Fork 未授权时提示重新登录社区
+### \[2026-02-09] Fork 未授权时提示重新登录社区
 
 - 类型: custom
-- 涉及文件: src/app/[variants]/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx; src/app/[variants]/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx; src/locales/default/discover.ts
-- 原因：Market 访问令牌失效/缺失时 fork 会返回 Unauthorized，原逻辑只显示通用失败提示
+- 涉及文件: src/app/\[variants]/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx; src/app/\[variants]/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx; src/locales/default/discover.ts
+- 原因：Market 访问令牌失效 / 缺失时 fork 会返回 Unauthorized，原逻辑只显示通用失败提示
 - 方案：捕获 Unauthorized 文案并提示用户先登录社区后重试
 - 回滚：移除 Unauthorized 分支提示逻辑与对应文案
 - 影响：仅影响 fork 失败提示，不改变后端调用逻辑
 
 ---
 
-### [2026-02-08] 增加关键 Hotfix 防回归校验脚本
+### \[2026-02-08] 增加关键 Hotfix 防回归校验脚本
 
 - 类型: custom
-- 涉及文件: scripts/checkCustomHotfixes.mts; package.json; src/_custom/SECONDARY_DEV_GUIDE.md
+- 涉及文件: scripts/checkCustomHotfixes.mts; package.json; src/\_custom/SECONDARY_DEV_GUIDE.md
 - 原因：reset/rebase/upstream-sync 后关键 hotfix 可能被历史重写导致丢失，发布时难以及时发现
 - 方案：新增 `custom:verify-hotfixes` 校验命令，支持检查 HEAD 或指定 refs（如 origin/dev、origin/main）中的关键补丁标记
 - 回滚：删除脚本与 package.json 对应命令，并移除文档说明
@@ -70,10 +143,10 @@
 
 ---
 
-### [2026-02-08] 修复 Vertex/Gemini 并行工具调用 400（functionResponse 对齐）
+### \[2026-02-08] 修复 Vertex/Gemini 并行工具调用 400（functionResponse 对齐）
 
 - 类型: hotfix
-- 涉及文件: packages/model-runtime/src/_custom/mergeGoogleFunctionResponses.ts; packages/model-runtime/src/_custom/mergeGoogleFunctionResponses.test.ts; packages/model-runtime/src/core/contextBuilders/google.ts; packages/model-runtime/src/core/contextBuilders/google.test.ts
+- 涉及文件: packages/model-runtime/src/\_custom/mergeGoogleFunctionResponses.ts; packages/model-runtime/src/\_custom/mergeGoogleFunctionResponses.test.ts; packages/model-runtime/src/core/contextBuilders/google.ts; packages/model-runtime/src/core/contextBuilders/google.test.ts
 - 原因：Google/Vertex 在单轮并行 functionCall 后要求下一轮为同一条 user 消息且 functionResponse parts 数量严格对齐；分成多条 tool 回包会触发 400 INVALID_ARGUMENT
 - 方案：在 Google context builder 中合并连续的 functionResponse user turn，确保并行工具结果以单条 user + 多 parts 回传
 - 回滚：删除 mergeGoogleFunctionResponses 注入与相关测试

--- a/src/_custom/CHANGELOG.md
+++ b/src/_custom/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ---
 
+### \[2026-03-09] 默认 inbox agent 新话题时清空 “关联文件” 勾选
+
+- 类型: custom
+- 涉及文件: src/app/\[variants]/(main)/home/\_layout/HomeAgentIdSync.tsx; src/store/agent/slices/knowledge/action.ts; src/store/agent/slices/knowledge/action.test.ts; src/store/chat/slices/topic/action.ts; src/store/chat/slices/topic/action.test.ts
+- 原因：默认 `cotti ai` /inbox agent 更接近 “临时聊天” 心智，用户开启新话题时，预期之前勾选的 “关联文件” 不应自动延续；但用户自定义 agent 仍需要保留该配置
+- 方案：新增 agent store `clearEnabledFiles` 动作，仅在 `switchTopic(null)` 且当前 agent 为 inbox agent 时批量关闭已启用的关联文件；首页 `HomeAgentIdSync` 仅负责在默认 agent 初始化后同步可用状态，不再额外改变已确认的刷新行为
+- 验证：`bunx vitest run --silent='passed-only' 'src/store/agent/slices/knowledge/action.test.ts'` 通过；`bunx vitest run --silent='passed-only' 'src/store/chat/slices/topic/action.test.ts'` 通过；页面实测当前行为为 “刷新不清空，新话题清空”
+- 回滚：删除 `clearEnabledFiles` 动作及 `switchTopic` 中对 inbox agent 的调用，恢复所有 agent 新话题时均保留关联文件勾选
+- 影响：仅影响默认 inbox agent 的 “新话题” 行为；刷新页面不清空；自定义 agent 保持原行为
+
 ### \[2026-03-09] Vertex 当前聊天上传 PDF 原生输入接线（v1）
 
 - 类型: custom

--- a/src/_custom/SESSION_HANDOFF_2026-03-09.md
+++ b/src/_custom/SESSION_HANDOFF_2026-03-09.md
@@ -1,0 +1,145 @@
+# Session Handoff - 2026-03-09
+
+最后更新: 2026-03-09
+
+## 本次目标
+
+围绕 `vertexai` 路径，把 PDF 能力从 “文本解析 fallback” 推进到 “Vertex 原生 PDF 输入可用”，并把用户感知上等价的两条路径打通：
+
+- 当前聊天直接上传 PDF
+- Agent 勾选 “关联文件” 里的 PDF
+
+同时修掉 Docker 运行环境里 PDF 解析报错，并按产品要求调整默认 agent 的 “关联文件勾选” 行为。
+
+## 今天已完成的修复
+
+### 1. Vertex 当前聊天上传 PDF 原生输入可用
+
+结果：
+
+- 当前聊天上传的 PDF，已可走 Vertex native PDF 输入链路
+- 不再只依赖旧的文本提取注入
+
+关键点：
+
+- 先用独立 PoC 脚本验证了 `@google/genai + vertexai: true + gs://...pdf` 可行
+- 服务端会把可用的 PDF 资源准备成 Vertex 可接受的 `gs://` URI
+- Vertex native 生效后，会移除误导模型的空文本 fallback
+
+相关文件：
+
+- `src/_custom/vertexPdfNativePoc.ts`
+- `src/_custom/services/vertexNativePdf.ts`
+
+对应提交：
+
+- `a45c272b66` 之前的相关修复
+
+### 2. 扫描版 PDF “明明成功了但仍回答看不到内容” 的问题已修
+
+问题根因：
+
+- Vertex native PDF 已经可读，但 prompt 里仍混入旧的 `<file>...</file>` 空文本 fallback
+- 对扫描件 / 无文本层 PDF，这会把 “提取为空” 的错误暗示暴露给模型，导致模型错误回答 “无法分析附件”
+
+结果：
+
+- native PDF 成功时，会清理掉对应空 fallback
+- 证照类扫描 PDF 已能基于视觉内容回答正文与边框样式
+
+### 3. Agent “关联文件” 中的 PDF 已复用 Vertex 原生 PDF 链路
+
+结果：
+
+- 用户当前聊天上传 PDF
+- 用户勾选 Agent 里的 “关联文件” PDF
+
+这两条路径现在对 Vertex 来说已经基本等价，都会尽量走 native PDF 输入。
+
+关键点：
+
+- 运行时保留 Agent 文件的 `url/type/size`
+- `KnowledgeInjector` 在 `vertexai` 下追加 `file_url` part
+- 服务端复用同一套 GCS 改写与 fallback 清理逻辑
+
+注意：
+
+- 这里说的是 Agent 关联文件
+- 不是知识库检索路径
+
+### 4. Docker 环境下 PDF 上传失败 `DOMMatrix is not defined` 已修
+
+问题根因：
+
+- 容器内 `@napi-rs/canvas` 的 optional native binding 没有正确暴露
+- 导致 `pdfjs-dist` 依赖的 `DOMMatrix` polyfill 失效
+
+结果：
+
+- Dockerfile 已补齐运行层链接逻辑
+- 页面实测后，上传 PDF 不再因这个错误失败
+
+### 5. 默认 agent `cotti ai` 的 “关联文件勾选” 行为已调整
+
+当前最终行为：
+
+- 刷新页面：不取消勾选
+- 开启新话题：取消勾选
+
+作用范围：
+
+- 只对默认 agent，也就是首页的 `cotti ai` /inbox agent 生效
+- 用户自定义的其他 agent，新话题时仍保留勾选
+
+这是当前你确认满意的行为，后续不要误改。
+
+## 当前未改动 / 保持原状
+
+### 1. 知识库路径没有重做成原生 PDF 直读
+
+当前知识库仍是检索式能力，不是把整份 PDF 直接作为 native document part 送给 Vertex。
+
+### 2. 刷新页面不会自动清空默认 agent 的勾选
+
+这个状态是当前确认后的最终要求，不是 bug。
+
+### 3. 非 Vertex provider 没有跟进这套 native PDF 逻辑
+
+本次只覆盖 `vertexai`。
+
+## 关键提交
+
+- `a45c272b66` `✨ feat: 接入 Vertex 原生 PDF 聊天与关联文件链路`
+- `3ba3829ef7` `✨ feat: 默认 agent 新话题时清空关联文件勾选`
+
+## 关键文件
+
+- `src/_custom/VERTEX_PDF_HANDOFF.md`
+- `src/_custom/vertexPdfNativePoc.ts`
+- `src/_custom/services/vertexNativePdf.ts`
+- `src/services/chat/mecha/contextEngineering.ts`
+- `packages/context-engine/src/providers/KnowledgeInjector.ts`
+- `packages/context-engine/src/engine/messages/MessagesEngine.ts`
+- `Dockerfile`
+- `src/app/[variants]/(main)/home/_layout/HomeAgentIdSync.tsx`
+- `src/store/agent/slices/knowledge/action.ts`
+- `src/store/chat/slices/topic/action.ts`
+
+## 已验证项
+
+- `bunx vitest run --silent='passed-only' 'src/_custom/services/vertexNativePdf.test.ts'`
+- `cd packages/context-engine && bunx vitest run --silent='passed-only' 'src/providers/__tests__/KnowledgeInjector.test.ts'`
+- `bunx vitest run --silent='passed-only' 'src/store/agent/slices/knowledge/action.test.ts'`
+- `bunx vitest run --silent='passed-only' 'src/store/chat/slices/topic/action.test.ts'`
+- Docker 已重建，`lobehub` 容器已成功启动
+
+## 下个会话建议开场
+
+如果下个会话要继续这条线，直接让模型先读这两个文件：
+
+- `/opt/lobechat-main/src/_custom/SESSION_HANDOFF_2026-03-09.md`
+- `/opt/lobechat-main/src/_custom/VERTEX_PDF_HANDOFF.md`
+
+可直接使用这句话：
+
+`先阅读 /opt/lobechat-main/src/_custom/SESSION_HANDOFF_2026-03-09.md 和 /opt/lobechat-main/src/_custom/VERTEX_PDF_HANDOFF.md，再继续。`

--- a/src/_custom/VERTEX_PDF_HANDOFF.md
+++ b/src/_custom/VERTEX_PDF_HANDOFF.md
@@ -1,0 +1,391 @@
+# Vertex PDF Native Input Handoff
+
+Last updated: 2026-03-09
+
+## Goal
+
+Current deployment only uses `vertexai`.
+
+Need to evaluate and then implement native PDF reading for Vertex AI, while keeping current injection-style customization discipline.
+
+The business requirement is:
+
+- User-uploaded files in the current chat must be readable by the model
+- Agent selected "关联文件" must be readable by the model
+- Agent selected "支持库 / 知识库" must still work
+
+Important: these three paths are not the same in current code.
+
+## What has already been fixed
+
+### 1. Chat upload race condition
+
+Problem:
+
+- Non-image/video files could be uploaded and then sent to the model before `parseFileContent` finished
+- In that case the model only saw URL / metadata, not parsed content
+
+Fix already implemented:
+
+- File: `src/store/file/slices/chat/action.ts`
+- Non-image/video chat files now remain in `processing` until `ragService.parseFileContent(fileId)` resolves
+- Parse failure is surfaced as explicit task error instead of silently proceeding
+
+Tests added and passed:
+
+- `src/store/file/slices/chat/action.test.ts`
+- `src/store/file/slices/chat/selectors.test.ts`
+
+### 2. Docker PDF parsing failure
+
+Problem found in logs:
+
+- `document.parseFileContent` failed with `ReferenceError: DOMMatrix is not defined`
+- Root cause was broken `@napi-rs/canvas` native binding resolution in the Docker runtime
+
+Fix already implemented:
+
+- File: `Dockerfile`
+- Added symlink logic so `@napi-rs/canvas` can resolve its platform binding in the app image
+
+Recorded in:
+
+- `src/_custom/CHANGELOG.md`
+
+User already verified that after the runtime fix, actual PDF parse succeeded.
+
+## Current architecture: three different document paths
+
+### A. User-uploaded file in current chat
+
+Path:
+
+1. Upload file
+2. `parseFileContent`
+3. Parsed text stored in `documents` table
+4. Message query attaches it into `fileList[].content`
+5. Context engine injects it into prompt as `<file ...>content</file>`
+
+Key files:
+
+- `src/store/file/slices/chat/action.ts`
+- `packages/database/src/models/message.ts`
+- `packages/context-engine/src/processors/MessageContent.ts`
+- `packages/prompts/src/prompts/files/file.ts`
+
+Conclusion:
+
+- This path is text extraction + prompt injection
+- It is not native Vertex PDF input
+
+### B. Agent selected "关联文件"
+
+Path:
+
+1. Agent config contains enabled files
+2. Runtime maps them to `knowledge.fileContents`
+3. Context engine injects them as agent knowledge
+
+Key files:
+
+- `src/server/modules/AgentRuntime/RuntimeExecutors.ts`
+- `src/server/modules/Mecha/ContextEngineering/index.ts`
+- `packages/prompts/src/prompts/files/knowledgeBase.ts`
+
+Conclusion:
+
+- This path is also text injection
+- It is not native Vertex PDF input
+
+### C. Agent selected "知识库 / 支持库"
+
+Path:
+
+1. Runtime injects knowledge base metadata only
+2. Model is expected to use `searchKnowledgeBase` tool for retrieval
+
+Key files:
+
+- `packages/prompts/src/prompts/files/knowledgeBase.ts`
+- `packages/context-engine/src/providers/KnowledgeInjector.ts`
+
+Conclusion:
+
+- This path is retrieval, not full-file direct reading
+- Do not confuse it with file full-text reading
+
+## Current Vertex AI integration status
+
+Current local implementation does use `@google/genai` with `vertexai: true`, but it does not support native file parts in the message builder.
+
+Verified code facts:
+
+- `packages/model-runtime/src/providers/vertexai/index.ts` creates `GoogleGenAI({ vertexai: true })`
+- `packages/model-runtime/src/types/chat.ts` only supports:
+  - `text`
+  - `image_url`
+  - `video_url`
+  - `thinking`
+- `packages/model-runtime/src/core/contextBuilders/google.ts` only converts:
+  - `text`
+  - `image_url`
+  - `video_url`
+
+There is no `fileData` / PDF part path right now.
+
+Conclusion:
+
+- Even though Gemini / Vertex models are multimodal, current project integration is not using native PDF input
+- Current PDF capability relies on parsing text first, then injecting prompt text
+
+## Official SDK / product conclusion
+
+Based on official Google / Vertex material:
+
+- Vertex AI supports native document understanding with PDF
+- In Node examples, this is passed as `fileData` with `fileUri`
+- Vertex AI path uses `gs://...` style URIs
+- `ai.files.upload()` is not the Vertex AI path
+
+Implication:
+
+- To use native PDF input on Vertex AI here, likely need a GCS-backed file URI flow
+- Current private app URL / S3 URL flow is not enough for native Vertex PDF input
+
+## GCS verification already completed
+
+Using current `.env` credentials, the following was verified successfully:
+
+- Vertex project available
+- Service account auth works
+- Bucket `lobechat-cotti` exists
+- Bucket location is `US`
+- Service account can list objects
+- Service account can upload a test object
+- Service account can read the object back
+- Service account can delete the object
+
+Verified service account:
+
+- `comfyui-vertex-agent@cotti-coffee-462402.iam.gserviceaccount.com`
+
+Verified bucket:
+
+- `gs://lobechat-cotti`
+
+Important:
+
+- GCS connectivity is no longer the blocker
+
+## What still needs to be done
+
+### Phase 1. Prove native Vertex PDF input works end-to-end
+
+Create a minimal standalone script that:
+
+1. Reads current Vertex config from `.env`
+2. Uses `@google/genai` with `vertexai: true`
+3. Sends a test request with:
+   - one text prompt
+   - one PDF `fileData` part using a `gs://lobechat-cotti/...pdf` URI
+4. Confirms model can answer based on PDF content
+
+Reason:
+
+- This removes product uncertainty before touching main business code
+
+Suggested output of this step:
+
+- A small script under `src/_custom/` or `scripts/`
+- A short test report in `src/_custom/CHANGELOG.md` or a nearby note
+
+### Phase 2. Decide integration scope
+
+Need a product/engineering decision:
+
+Option A:
+
+- Only native-handle current chat uploaded PDFs
+
+Option B:
+
+- Native-handle current chat uploaded PDFs + agent selected files
+
+Option C:
+
+- Also redesign knowledge base path
+
+Recommended:
+
+- Start with A + B
+- Keep knowledge base retrieval as-is for now
+
+Reason:
+
+- Knowledge base is a retrieval system, not a direct file transport system
+- Mixing them now will increase scope too much
+
+### Phase 3. Extend runtime message schema
+
+Need to add a file part type into model runtime shared message schema.
+
+Current gap:
+
+- `UserMessageContentPart` has no file/PDF part
+
+Likely work:
+
+- Update `packages/model-runtime/src/types/chat.ts`
+- Add a new content part, likely something like:
+  - `type: 'file_url'`
+  - or a provider-specific normalized file part
+
+Design caution:
+
+- Do not hardcode only PDF unless intentionally scoping it that way
+- But for the first delivery, PDF-only may be acceptable if business target is clear
+
+### Phase 4. Add Google/Vertex file part builder
+
+Need to extend:
+
+- `packages/model-runtime/src/core/contextBuilders/google.ts`
+
+New behavior:
+
+- When provider is Vertex and part is native file input, build Google `Part.fileData`
+- Use `mimeType: application/pdf`
+- Use `fileUri: gs://...`
+
+Need to decide:
+
+- Whether this path should be gated by provider only
+- Whether to fall back to current text injection if native file URI is unavailable
+
+Recommended:
+
+- Use fallback
+
+Reason:
+
+- Safer rollout
+- Prevent regression if GCS sync fails
+
+### Phase 5. Build GCS sync path for files
+
+Need a custom flow to turn existing app files into GCS objects usable by Vertex.
+
+Current system stores user files in app file storage / S3-compatible storage, not GCS.
+
+Need to implement:
+
+1. For target PDFs, create or reuse a GCS object path
+2. Upload/copy file bytes into `gs://lobechat-cotti/...`
+3. Persist mapping if needed to avoid repeated uploads
+4. Generate native file content part from that GCS URI
+
+Likely design choices:
+
+- Store mapping in metadata or a custom table
+- Or start with on-demand upload without persistence for first version
+
+Recommended first version:
+
+- On-demand upload with deterministic object key
+- Reuse if object already exists
+
+### Phase 6. Wire the two business paths
+
+#### 6A. Current chat uploaded files
+
+When message includes uploaded PDF:
+
+- If provider is `vertexai`
+- And file is PDF
+- And GCS sync succeeds
+
+Then:
+
+- send native `fileData` part
+
+Else:
+
+- keep existing parsed-text injection path
+
+#### 6B. Agent selected "关联文件"
+
+When runtime builds agent file knowledge:
+
+- For Vertex + PDF files, consider native file part path
+- For others, keep current `knowledge.fileContents`
+
+Important:
+
+- Avoid breaking existing non-PDF files
+- Avoid removing current text-injection fallback until native path is proven stable
+
+### Phase 7. Keep knowledge base path unchanged for now
+
+Do not rewrite knowledge base path in the first iteration.
+
+Reason:
+
+- Knowledge base currently means retrieval/chunk search
+- Native PDF transport does not replace semantic retrieval
+- This is a different product behavior
+
+## Recommended implementation order
+
+1. Add a minimal standalone Vertex PDF proof script
+2. Verify one real PDF can be answered from `gs://lobechat-cotti/...`
+3. Add normalized file part type to model runtime schema
+4. Add Google/Vertex `fileData` builder
+5. Add GCS sync utility
+6. Wire current chat uploaded PDFs
+7. Verify no regression
+8. Wire agent selected PDFs
+9. Verify again
+10. Leave knowledge base retrieval unchanged
+
+## Exact files that likely need changes next
+
+Very likely:
+
+- `packages/model-runtime/src/types/chat.ts`
+- `packages/model-runtime/src/core/contextBuilders/google.ts`
+- `packages/model-runtime/src/providers/google/index.ts`
+- `packages/model-runtime/src/providers/vertexai/index.ts`
+
+Likely custom/business-side files:
+
+- `src/server/modules/AgentRuntime/RuntimeExecutors.ts`
+- `src/server/modules/Mecha/ContextEngineering/index.ts`
+- `src/store/file/slices/chat/action.ts` only if UI state or flow gating must change
+
+Possibly new helper/service files:
+
+- a custom GCS upload helper under `src/_custom/` or suitable server service path
+- a temporary proof script under `src/_custom/` or `scripts/`
+
+## Constraints and rules for future work
+
+- This repo is being developed in an injection-style/custom manner
+- Prefer minimal invasive changes
+- Record exceptions in `src/_custom/CHANGELOG.md`
+- Do not remove existing text parsing fallback too early
+- Do not treat knowledge base retrieval as equivalent to file direct reading
+
+## Suggested prompt for the next session
+
+Use this file as the working context and continue from here.
+
+High-priority task:
+
+- Implement and run a minimal proof-of-concept that uses current Vertex credentials and bucket `gs://lobechat-cotti` to send one PDF to Gemini through native `fileData` input, without changing main business flow yet.
+
+After that:
+
+- Propose the smallest-change production integration plan for:
+  - current chat uploaded PDF files
+  - agent selected related files
+- Keep knowledge base retrieval unchanged in v1

--- a/src/_custom/registry/modelCustomization.test.ts
+++ b/src/_custom/registry/modelCustomization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getThinkingLevel3Default, resolveModelDetailDescription } from './modelCustomization';
+
+describe('modelCustomization', () => {
+  describe('getThinkingLevel3Default', () => {
+    it('returns low as default thinking level', () => {
+      expect(getThinkingLevel3Default()).toBe('low');
+    });
+  });
+
+  describe('resolveModelDetailDescription', () => {
+    it('keeps localized fallback description when available', () => {
+      const result = resolveModelDetailDescription({
+        fallbackDescription: '这是本地化描述',
+        modelDescription: 'English runtime description',
+        modelId: 'gemini-3.1-pro-preview',
+      });
+
+      expect(result).toBe('这是本地化描述');
+    });
+
+    it('falls back to runtime description when i18n key is unresolved', () => {
+      const result = resolveModelDetailDescription({
+        fallbackDescription: 'gemini-3.1-pro-preview.description',
+        modelDescription: 'English runtime description',
+        modelId: 'gemini-3.1-pro-preview',
+      });
+
+      expect(result).toBe('English runtime description');
+    });
+  });
+});

--- a/src/_custom/registry/modelCustomization.ts
+++ b/src/_custom/registry/modelCustomization.ts
@@ -1,0 +1,107 @@
+import { getModelPropertyWithFallback } from '@lobechat/model-runtime';
+import { type EnabledAiModel } from 'model-bank';
+
+type ThinkingLevel3 = 'low' | 'medium' | 'high';
+
+const TRUTHY_ENV_VALUES = new Set(['1', 'on', 'true', 'yes']);
+const DESCRIPTION_ALIAS_SWITCH = 'NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE';
+
+const isModelAliasDescriptionRewriteEnabled = () => {
+  const rawValue = process.env[DESCRIPTION_ALIAS_SWITCH];
+  if (rawValue === undefined) return true;
+
+  return TRUTHY_ENV_VALUES.has(rawValue.trim().toLowerCase());
+};
+
+const normalizeAliasCandidate = (value?: string) => value?.replaceAll(/\s+/g, ' ').trim() || '';
+
+const stripModelSuffix = (value: string) =>
+  normalizeAliasCandidate(value.replaceAll(/\b(preview|experimental|exp)\b/gi, ''));
+
+const stripMinorVersion = (value: string) =>
+  normalizeAliasCandidate(value.replaceAll(/\b(\d+)\.(\d+)\b/g, '$1'));
+
+const buildAliasCandidates = (fallbackDisplayName?: string) => {
+  const normalizedDisplayName = normalizeAliasCandidate(fallbackDisplayName);
+  if (!normalizedDisplayName) return [];
+
+  const aliases = new Set<string>([
+    normalizedDisplayName,
+    stripModelSuffix(normalizedDisplayName),
+    stripMinorVersion(normalizedDisplayName),
+    stripMinorVersion(stripModelSuffix(normalizedDisplayName)),
+  ]);
+
+  return [...aliases].filter(Boolean).sort((a, b) => b.length - a.length);
+};
+
+export const getThinkingLevel3Default = (): ThinkingLevel3 => 'low';
+
+export const resolveThinkingLevel3Param = (value?: ThinkingLevel3): ThinkingLevel3 =>
+  value || getThinkingLevel3Default();
+
+export const resolveModelDescriptionWithAlias = (params: {
+  customDescription?: string;
+  fallbackDescription?: string;
+  fallbackDisplayName?: string;
+  modelDisplayName?: string;
+}) => {
+  const { customDescription, fallbackDescription, fallbackDisplayName, modelDisplayName } = params;
+  const description = customDescription ?? fallbackDescription;
+
+  if (!description) return description;
+
+  if (modelDisplayName && fallbackDisplayName && modelDisplayName !== fallbackDisplayName) {
+    let rewrittenDescription = description;
+    const aliases = isModelAliasDescriptionRewriteEnabled()
+      ? buildAliasCandidates(fallbackDisplayName)
+      : [normalizeAliasCandidate(fallbackDisplayName)];
+
+    for (const alias of aliases) {
+      if (!alias || alias === modelDisplayName || !rewrittenDescription.includes(alias)) continue;
+      rewrittenDescription = rewrittenDescription.replaceAll(alias, modelDisplayName);
+    }
+
+    return rewrittenDescription;
+  }
+
+  return description;
+};
+
+export const resolveCustomizedModelDescription = async (params: {
+  fallbackDescription?: string;
+  model: EnabledAiModel;
+}) => {
+  const { fallbackDescription, model } = params;
+  const customDescription = (model as EnabledAiModel & { description?: string }).description;
+
+  const fallbackDisplayName = await getModelPropertyWithFallback<string | undefined>(
+    model.id,
+    'displayName',
+    model.providerId,
+  );
+
+  return resolveModelDescriptionWithAlias({
+    customDescription,
+    fallbackDescription,
+    fallbackDisplayName,
+    modelDisplayName: model.displayName,
+  });
+};
+
+export const resolveModelDetailDescription = (params: {
+  modelId: string;
+  fallbackDescription: string;
+  modelDescription?: string;
+}) => {
+  const { fallbackDescription, modelDescription, modelId } = params;
+
+  // i18n key fallback (e.g. "gemini-3-pro-preview.description") means locale text is missing.
+  // In that case, prefer runtime model description.
+  if (!fallbackDescription || fallbackDescription === `${modelId}.description`) {
+    return modelDescription || fallbackDescription;
+  }
+
+  // Locale description exists: keep localized copy to avoid language regression.
+  return fallbackDescription;
+};

--- a/src/_custom/services/vertexNativePdf.test.ts
+++ b/src/_custom/services/vertexNativePdf.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripNativePdfFallbackPrompt } from './vertexNativePdf';
+
+describe('stripNativePdfFallbackPrompt', () => {
+  it('removes matching PDF fallback file prompts after native gs uri is ready', () => {
+    const text = `<!-- SYSTEM CONTEXT (NOT PART OF USER QUERY) -->
+<context.instruction>following part contains context information injected by the system. Please follow these instructions:
+
+1. Always prioritize handling user-visible content.
+2. the context is only required when user's queries rely on it.
+</context.instruction>
+<files_info>
+<files>
+<files_docstring>here are user upload files you can refer to</files_docstring>
+<file id="pdf-1" name="license.pdf" type="application/pdf" size="1024" url="https://example.com/license.pdf"></file>
+<file id="txt-1" name="note.txt" type="text/plain" size="12" url="https://example.com/note.txt">keep me</file>
+</files>
+</files_info>
+<!-- END SYSTEM CONTEXT -->`;
+
+    const result = stripNativePdfFallbackPrompt(text, [
+      {
+        file_url: {
+          id: 'pdf-1',
+          mimeType: 'application/pdf',
+          name: 'license.pdf',
+          url: 'gs://lobechat-cotti/native/license.pdf',
+        },
+        type: 'file_url',
+      },
+    ]);
+
+    expect(result).not.toContain('license.pdf');
+    expect(result).toContain('note.txt');
+    expect(result).toContain('keep me');
+  });
+
+  it('removes empty files containers left behind by stripped native pdf prompts', () => {
+    const text = `<files_info>
+<files>
+<files_docstring>here are user upload files you can refer to</files_docstring>
+<file id="pdf-1" name="license.pdf" type="application/pdf" size="1024" url="https://example.com/license.pdf"></file>
+</files>
+</files_info>`;
+
+    const result = stripNativePdfFallbackPrompt(text, [
+      {
+        file_url: {
+          id: 'pdf-1',
+          mimeType: 'application/pdf',
+          name: 'license.pdf',
+          url: 'gs://lobechat-cotti/native/license.pdf',
+        },
+        type: 'file_url',
+      },
+    ]);
+
+    expect(result).toBe('');
+  });
+
+  it('removes agent knowledge pdf fallback blocks after native gs uri is ready', () => {
+    const text = `<agent_knowledge>
+<instruction>The following files are available. Refer to their content directly to answer questions. No knowledge bases are associated.</instruction>
+<files totalCount="1">
+<file id="pdf-1" name="license.pdf">
+Extracted OCR text that should be ignored after native PDF succeeds.
+</file>
+</files>
+</agent_knowledge>`;
+
+    const result = stripNativePdfFallbackPrompt(text, [
+      {
+        file_url: {
+          id: 'pdf-1',
+          mimeType: 'application/pdf',
+          name: 'license.pdf',
+          url: 'gs://lobechat-cotti/native/license.pdf',
+        },
+        type: 'file_url',
+      },
+    ]);
+
+    expect(result).not.toContain('license.pdf');
+    expect(result).not.toContain('<files totalCount=');
+    expect(result).toContain('<agent_knowledge>');
+  });
+});

--- a/src/_custom/services/vertexNativePdf.ts
+++ b/src/_custom/services/vertexNativePdf.ts
@@ -1,0 +1,476 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { GoogleGenAIOptions } from '@google/genai';
+import type { LobeChatDatabase } from '@lobechat/database';
+import type { OpenAIChatMessage, UserMessageContentPart } from '@lobechat/types';
+import { importPKCS8, SignJWT } from 'jose';
+
+import { FileModel } from '@/database/models/file';
+import { FileService } from '@/server/services/file';
+
+export const VERTEX_NATIVE_PDF_MIME_TYPE = 'application/pdf';
+
+const DEFAULT_VERTEX_BUCKET = 'lobechat-cotti';
+const DEFAULT_VERTEX_LOCATION = 'global';
+const STORAGE_SCOPE = 'https://www.googleapis.com/auth/devstorage.read_write';
+
+interface ResolvedCredentials {
+  credentials?: Record<string, unknown>;
+  project?: string;
+}
+
+interface ServiceAccountCredentials extends Record<string, unknown> {
+  client_email?: string;
+  private_key?: string;
+  private_key_id?: string;
+  token_uri?: string;
+  type?: string;
+}
+
+interface EnsureVertexPdfGcsUriParams {
+  bucket?: string;
+  bytes: Uint8Array;
+  fileHash?: string | null;
+  fileName: string;
+  objectKey?: string;
+  vertexOptions: GoogleGenAIOptions;
+}
+
+interface PrepareVertexNativePdfMessagesParams {
+  bucket?: string;
+  messages: OpenAIChatMessage[];
+  serverDB: LobeChatDatabase;
+  userId: string;
+}
+
+type FileUrlPart = Extract<UserMessageContentPart, { type: 'file_url' }>;
+type TextPart = Extract<UserMessageContentPart, { type: 'text' }>;
+
+const safeParseJSON = (value: string | undefined): Record<string, unknown> | undefined => {
+  if (!value) return undefined;
+
+  try {
+    return JSON.parse(value) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveCredentialsFromEnv = async (): Promise<ResolvedCredentials> => {
+  const credentialsFromEnv = safeParseJSON(process.env.VERTEXAI_CREDENTIALS);
+  if (credentialsFromEnv) {
+    return {
+      credentials: credentialsFromEnv,
+      project:
+        typeof credentialsFromEnv.project_id === 'string'
+          ? credentialsFromEnv.project_id
+          : undefined,
+    };
+  }
+
+  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!credentialsPath) return {};
+
+  const rawCredentials = await readFile(path.resolve(credentialsPath), 'utf8');
+  const credentialsFromFile = safeParseJSON(rawCredentials);
+
+  if (!credentialsFromFile) {
+    throw new Error(`Failed to parse GOOGLE_APPLICATION_CREDENTIALS from ${credentialsPath}`);
+  }
+
+  return {
+    credentials: credentialsFromFile,
+    project:
+      typeof credentialsFromFile.project_id === 'string'
+        ? credentialsFromFile.project_id
+        : undefined,
+  };
+};
+
+export const buildVertexGenAIOptionsFromEnv = async (
+  overrides: Partial<GoogleGenAIOptions> = {},
+): Promise<GoogleGenAIOptions> => {
+  const { credentials, project: projectFromCredentials } = await resolveCredentialsFromEnv();
+
+  const project =
+    (overrides.project as string | undefined) ||
+    process.env.VERTEXAI_PROJECT ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    projectFromCredentials;
+
+  if (!project) {
+    throw new Error(
+      'Missing Vertex project. Set VERTEXAI_PROJECT or include project_id in VERTEXAI_CREDENTIALS.',
+    );
+  }
+
+  const location =
+    (overrides.location as string | undefined) ||
+    process.env.VERTEXAI_LOCATION ||
+    process.env.GOOGLE_CLOUD_LOCATION ||
+    DEFAULT_VERTEX_LOCATION;
+
+  const options: GoogleGenAIOptions = {
+    ...overrides,
+    location,
+    project,
+    vertexai: true,
+  };
+
+  if (credentials) {
+    options.googleAuthOptions = {
+      ...overrides.googleAuthOptions,
+      credentials,
+    };
+  }
+
+  return options;
+};
+
+const getAccessToken = async (vertexOptions: GoogleGenAIOptions): Promise<string> => {
+  const credentials = vertexOptions.googleAuthOptions?.credentials as
+    | ServiceAccountCredentials
+    | undefined;
+
+  if (!credentials) {
+    throw new Error(
+      'Missing service account credentials for Vertex PDF GCS sync. Set VERTEXAI_CREDENTIALS.',
+    );
+  }
+
+  if (credentials.type !== 'service_account') {
+    throw new Error(
+      `Unsupported Google credential type for Vertex PDF GCS sync: ${credentials.type || 'unknown'}`,
+    );
+  }
+
+  if (!credentials.client_email || !credentials.private_key) {
+    throw new Error('VERTEXAI_CREDENTIALS must include client_email and private_key');
+  }
+
+  const tokenUri = credentials.token_uri || 'https://oauth2.googleapis.com/token';
+  const key = await importPKCS8(credentials.private_key, 'RS256');
+  const now = Math.floor(Date.now() / 1000);
+
+  const assertion = await new SignJWT({ scope: STORAGE_SCOPE })
+    .setProtectedHeader({
+      alg: 'RS256',
+      ...(credentials.private_key_id ? { kid: credentials.private_key_id } : {}),
+      typ: 'JWT',
+    })
+    .setIssuer(credentials.client_email)
+    .setSubject(credentials.client_email)
+    .setAudience(tokenUri)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(key);
+
+  const response = await fetch(tokenUri, {
+    body: new URLSearchParams({
+      assertion,
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    }),
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to acquire Google access token for Vertex PDF GCS sync (${response.status}): ${await response.text()}`,
+    );
+  }
+
+  const result = (await response.json()) as { access_token?: string };
+  if (!result.access_token) {
+    throw new Error('Google OAuth token response did not include access_token');
+  }
+
+  return result.access_token;
+};
+
+const toObjectMetadataUrl = (bucket: string, objectKey: string) =>
+  `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucket)}/o/${encodeURIComponent(objectKey)}`;
+
+const toObjectUploadUrl = (bucket: string, objectKey: string) =>
+  `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(
+    bucket,
+  )}/o?uploadType=media&name=${encodeURIComponent(objectKey)}`;
+
+const normalizeFileName = (fileName: string) => {
+  const normalized = path.basename(fileName).replaceAll(/[^\w.-]/g, '_');
+  return normalized || 'document.pdf';
+};
+
+const resolveObjectKey = ({
+  fileHash,
+  fileName,
+  objectKey,
+  bytes,
+}: {
+  bytes: Uint8Array;
+  fileHash?: string | null;
+  fileName: string;
+  objectKey?: string;
+}) => {
+  if (objectKey) return objectKey;
+
+  const hash = fileHash || createHash('sha256').update(bytes).digest('hex');
+  return `vertex-native-pdf/chat-upload/${hash}/${normalizeFileName(fileName)}`;
+};
+
+const isGsUri = (url: string) => url.startsWith('gs://');
+
+const escapeRegExp = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const isTextPart = (part: UserMessageContentPart | undefined): part is TextPart =>
+  part?.type === 'text';
+
+export const stripNativePdfFallbackPrompt = (
+  text: string,
+  nativePdfParts: FileUrlPart[],
+): string => {
+  let nextText = text;
+
+  for (const part of nativePdfParts) {
+    const mimeType = part.file_url.mimeType || VERTEX_NATIVE_PDF_MIME_TYPE;
+    const escapedMimeType = escapeRegExp(mimeType);
+    const escapedId = part.file_url.id ? escapeRegExp(part.file_url.id) : undefined;
+    const escapedName = part.file_url.name ? escapeRegExp(part.file_url.name) : undefined;
+
+    if (escapedId) {
+      nextText = nextText.replaceAll(
+        new RegExp(
+          `<file\\b[^>]*\\bid="${escapedId}"(?:[^>]*\\btype="${escapedMimeType}")?[^>]*>([\\s\\S]*?)<\\/file>\\s*`,
+          'g',
+        ),
+        '',
+      );
+      nextText = nextText.replaceAll(
+        new RegExp(
+          `<file\\b[^>]*\\bid="${escapedId}"(?:[^>]*\\btype="${escapedMimeType}")?[^>]*/>\\s*`,
+          'g',
+        ),
+        '',
+      );
+      continue;
+    }
+
+    if (escapedName) {
+      nextText = nextText.replaceAll(
+        new RegExp(
+          `<file\\b[^>]*\\bname="${escapedName}"(?:[^>]*\\btype="${escapedMimeType}")?[^>]*>([\\s\\S]*?)<\\/file>\\s*`,
+          'g',
+        ),
+        '',
+      );
+      nextText = nextText.replaceAll(
+        new RegExp(
+          `<file\\b[^>]*\\bname="${escapedName}"(?:[^>]*\\btype="${escapedMimeType}")?[^>]*/>\\s*`,
+          'g',
+        ),
+        '',
+      );
+    }
+  }
+
+  nextText = nextText
+    .replaceAll(
+      /<files>\s*<files_docstring>here are user upload files you can refer to<\/files_docstring>\s*<\/files>\s*/g,
+      '',
+    )
+    .replaceAll(/<files_info>\s*<\/files_info>\s*/g, '')
+    .replaceAll(/<files\b[^>]*>\s*<\/files>\s*/g, '')
+    .replaceAll(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return nextText;
+};
+
+export const isVertexNativePdfPart = (
+  part: UserMessageContentPart | undefined,
+): part is FileUrlPart => {
+  return (
+    part?.type === 'file_url' &&
+    part.file_url.mimeType?.toLowerCase() === VERTEX_NATIVE_PDF_MIME_TYPE
+  );
+};
+
+export const ensureVertexPdfGcsUri = async ({
+  bytes,
+  fileHash,
+  fileName,
+  objectKey,
+  vertexOptions,
+  bucket = process.env.VERTEX_PDF_NATIVE_BUCKET || DEFAULT_VERTEX_BUCKET,
+}: EnsureVertexPdfGcsUriParams): Promise<string> => {
+  const resolvedObjectKey = resolveObjectKey({ bytes, fileHash, fileName, objectKey });
+  const gcsUri = `gs://${bucket}/${resolvedObjectKey}`;
+  const accessToken = await getAccessToken(vertexOptions);
+
+  const metadataResponse = await fetch(toObjectMetadataUrl(bucket, resolvedObjectKey), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (metadataResponse.ok) return gcsUri;
+
+  if (metadataResponse.status !== 404) {
+    throw new Error(
+      `Failed to query Vertex PDF GCS object (${metadataResponse.status}): ${await metadataResponse.text()}`,
+    );
+  }
+
+  const uploadResponse = await fetch(toObjectUploadUrl(bucket, resolvedObjectKey), {
+    body: Buffer.from(bytes),
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Length': String(bytes.byteLength),
+      'Content-Type': VERTEX_NATIVE_PDF_MIME_TYPE,
+    },
+    method: 'POST',
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error(
+      `Failed to upload Vertex PDF to GCS (${uploadResponse.status}): ${await uploadResponse.text()}`,
+    );
+  }
+
+  return gcsUri;
+};
+
+const resolveBytesFromFilePart = async (
+  filePart: FileUrlPart,
+  fileModel: FileModel,
+  fileService: FileService,
+): Promise<{ bytes: Uint8Array; fileHash?: string | null; fileName: string } | undefined> => {
+  const fileId = filePart.file_url.id;
+
+  if (fileId) {
+    const file = await fileModel.findById(fileId);
+    if (file?.url) {
+      const bytes = await fileService.getFileByteArray(file.url);
+
+      return {
+        bytes,
+        fileHash: file.fileHash,
+        fileName: file.name,
+      };
+    }
+  }
+
+  const sourceUrl = filePart.file_url.url;
+  if (!sourceUrl || isGsUri(sourceUrl)) return undefined;
+
+  const response = await fetch(sourceUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch PDF from ${sourceUrl}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return {
+    bytes: new Uint8Array(await response.arrayBuffer()),
+    fileHash: undefined,
+    fileName: filePart.file_url.name || 'document.pdf',
+  };
+};
+
+export const prepareVertexNativePdfMessages = async ({
+  messages,
+  serverDB,
+  userId,
+  bucket,
+}: PrepareVertexNativePdfMessagesParams): Promise<OpenAIChatMessage[]> => {
+  const hasVertexPdfPart = messages.some(
+    (message) =>
+      Array.isArray(message.content) &&
+      message.content.some((part) => isVertexNativePdfPart(part as UserMessageContentPart)),
+  );
+
+  if (!hasVertexPdfPart) return messages;
+
+  let vertexOptions: GoogleGenAIOptions;
+  try {
+    vertexOptions = await buildVertexGenAIOptionsFromEnv();
+  } catch (error) {
+    console.error('[vertex-native-pdf] Failed to resolve Vertex options:', error);
+    return messages;
+  }
+
+  const fileModel = new FileModel(serverDB, userId);
+  const fileService = new FileService(serverDB, userId);
+  let hasChanges = false;
+
+  const nextMessages = await Promise.all(
+    messages.map(async (message) => {
+      if (!Array.isArray(message.content)) return message;
+
+      const preparedContent = await Promise.all(
+        message.content.map(async (part) => {
+          if (!isVertexNativePdfPart(part)) return part;
+          if (isGsUri(part.file_url.url)) return part;
+
+          try {
+            const fileData = await resolveBytesFromFilePart(part, fileModel, fileService);
+            if (!fileData) return part;
+
+            const gcsUri = await ensureVertexPdfGcsUri({
+              bucket,
+              bytes: fileData.bytes,
+              fileHash: fileData.fileHash,
+              fileName: fileData.fileName,
+              vertexOptions,
+            });
+
+            hasChanges = true;
+
+            return {
+              ...part,
+              file_url: {
+                ...part.file_url,
+                url: gcsUri,
+              },
+            };
+          } catch (error) {
+            console.error('[vertex-native-pdf] Failed to prepare PDF part:', error);
+            return part;
+          }
+        }),
+      );
+
+      const nativePdfParts = preparedContent.filter((part) =>
+        isVertexNativePdfPart(part as UserMessageContentPart),
+      ) as FileUrlPart[];
+      const readyNativePdfParts = nativePdfParts.filter((part) => isGsUri(part.file_url.url));
+
+      let messageChanged = preparedContent !== message.content;
+      const nextContent =
+        readyNativePdfParts.length === 0
+          ? preparedContent
+          : preparedContent.map((part) => {
+              const typedPart = part as UserMessageContentPart;
+              if (!isTextPart(typedPart)) return part;
+
+              const nextText = stripNativePdfFallbackPrompt(typedPart.text, readyNativePdfParts);
+              if (nextText !== typedPart.text) messageChanged = true;
+
+              return {
+                ...part,
+                text: nextText,
+              };
+            });
+
+      if (messageChanged) hasChanges = true;
+
+      return messageChanged ? { ...message, content: nextContent } : message;
+    }),
+  );
+
+  return hasChanges ? nextMessages : messages;
+};

--- a/src/_custom/vertexPdfNativePoc.ts
+++ b/src/_custom/vertexPdfNativePoc.ts
@@ -1,0 +1,275 @@
+import { existsSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { GenerateContentResponse, GoogleGenAIOptions } from '@google/genai';
+import { GoogleGenAI } from '@google/genai';
+import * as dotenv from 'dotenv';
+import * as dotenvExpand from 'dotenv-expand';
+
+import {
+  buildVertexGenAIOptionsFromEnv,
+  ensureVertexPdfGcsUri,
+  VERTEX_NATIVE_PDF_MIME_TYPE,
+} from './services/vertexNativePdf';
+
+const DEFAULT_BUCKET = 'lobechat-cotti';
+const DEFAULT_FILE_PATH = 'packages/file-loaders/test/fixtures/test.pdf';
+const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_PROMPT = 'Read the PDF and reply with only the number shown in the document.';
+
+interface CliArgs {
+  bucket?: string;
+  file?: string;
+  gcsUri?: string;
+  help: boolean;
+  location?: string;
+  model?: string;
+  objectKey?: string;
+  project?: string;
+  prompt?: string;
+}
+
+interface VertexPocConfig {
+  bucket: string;
+  filePath: string;
+  gcsUri?: string;
+  model: string;
+  objectKey?: string;
+  prompt: string;
+  vertexOptions: GoogleGenAIOptions;
+}
+
+const loadEnv = () => {
+  const env = process.env.NODE_ENV || 'development';
+  const envFiles = ['.env', `.env.${env}`, '.env.local', `.env.${env}.local`];
+
+  for (let index = 0; index < envFiles.length; index += 1) {
+    const path = envFiles[index];
+    if (!existsSync(path)) continue;
+
+    dotenvExpand.expand(
+      dotenv.config({
+        override: index > 0,
+        path,
+        quiet: true,
+      }),
+    );
+  }
+};
+
+const parseArgs = (argv: string[]): CliArgs => {
+  const args: CliArgs = { help: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+
+    switch (current) {
+      case '-h':
+      case '--help': {
+        args.help = true;
+        break;
+      }
+
+      case '--bucket': {
+        args.bucket = argv[++index];
+        break;
+      }
+
+      case '--file': {
+        args.file = argv[++index];
+        break;
+      }
+
+      case '--gcs-uri': {
+        args.gcsUri = argv[++index];
+        break;
+      }
+
+      case '--location': {
+        args.location = argv[++index];
+        break;
+      }
+
+      case '--model': {
+        args.model = argv[++index];
+        break;
+      }
+
+      case '--object-key': {
+        args.objectKey = argv[++index];
+        break;
+      }
+
+      case '--project': {
+        args.project = argv[++index];
+        break;
+      }
+
+      case '--prompt': {
+        args.prompt = argv[++index];
+        break;
+      }
+
+      default: {
+        throw new Error(`Unknown argument: ${current}`);
+      }
+    }
+
+    if (current.startsWith('--') && !args.help) {
+      const value = argv[index];
+      if (!value) throw new Error(`Missing value for ${current}`);
+    }
+  }
+
+  return args;
+};
+
+const printHelp = () => {
+  console.info(`Vertex native PDF PoC
+
+Usage:
+  bunx tsx src/_custom/vertexPdfNativePoc.ts [options]
+
+Options:
+  --file <path>        Local PDF path to upload. Defaults to ${DEFAULT_FILE_PATH}
+  --gcs-uri <uri>      Existing gs:// URI. Skips upload when provided
+  --bucket <name>      GCS bucket name. Defaults to ${DEFAULT_BUCKET}
+  --object-key <key>   Object key to reuse in the bucket
+  --model <id>         Vertex model id. Defaults to ${DEFAULT_MODEL}
+  --project <id>       Vertex project override
+  --location <name>    Vertex location override
+  --prompt <text>      Prompt to send with the PDF
+  -h, --help           Show this help
+
+Environment:
+  VERTEXAI_CREDENTIALS
+  VERTEXAI_PROJECT
+  VERTEXAI_LOCATION
+  VERTEX_PDF_POC_BUCKET
+  VERTEX_PDF_POC_FILE
+  VERTEX_PDF_POC_GCS_URI
+  VERTEX_PDF_POC_MODEL
+  VERTEX_PDF_POC_OBJECT_KEY
+  VERTEX_PDF_POC_PROMPT
+`);
+};
+
+const resolveVertexConfig = async (args: CliArgs): Promise<VertexPocConfig> => {
+  const vertexOptions = await buildVertexGenAIOptionsFromEnv({
+    location: args.location,
+    project: args.project,
+  });
+
+  return {
+    bucket: args.bucket || process.env.VERTEX_PDF_POC_BUCKET || DEFAULT_BUCKET,
+    filePath: path.resolve(args.file || process.env.VERTEX_PDF_POC_FILE || DEFAULT_FILE_PATH),
+    gcsUri: args.gcsUri || process.env.VERTEX_PDF_POC_GCS_URI,
+    model: args.model || process.env.VERTEX_PDF_POC_MODEL || DEFAULT_MODEL,
+    objectKey: args.objectKey || process.env.VERTEX_PDF_POC_OBJECT_KEY,
+    prompt: args.prompt || process.env.VERTEX_PDF_POC_PROMPT || DEFAULT_PROMPT,
+    vertexOptions,
+  };
+};
+
+const ensureGcsObject = async (config: VertexPocConfig): Promise<string> => {
+  if (config.gcsUri) return config.gcsUri;
+
+  if (!existsSync(config.filePath)) {
+    throw new Error(`PDF file not found: ${config.filePath}`);
+  }
+
+  const pdfBuffer = await readFile(config.filePath);
+  const fileStats = await stat(config.filePath);
+  const gcsUri = await ensureVertexPdfGcsUri({
+    bucket: config.bucket,
+    bytes: pdfBuffer,
+    fileHash: undefined,
+    fileName: config.filePath,
+    objectKey:
+      config.objectKey ||
+      `vertex-pdf-poc/${fileStats.size}-${path.resolve(config.filePath).split('/').pop()}`,
+    vertexOptions: config.vertexOptions,
+  });
+
+  console.info(`Uploaded PDF to GCS: ${gcsUri}`);
+  return gcsUri;
+};
+
+const extractResponseText = (response: GenerateContentResponse): string => {
+  if (response.text?.trim()) return response.text.trim();
+
+  const fallbackText = response.candidates
+    ?.flatMap((candidate) => candidate.content?.parts || [])
+    .map((part) => part.text?.trim())
+    .filter(Boolean)
+    .join('\n')
+    .trim();
+
+  if (fallbackText) return fallbackText;
+
+  return '';
+};
+
+const run = async () => {
+  loadEnv();
+
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const config = await resolveVertexConfig(args);
+  const gcsUri = await ensureGcsObject(config);
+  const ai = new GoogleGenAI(config.vertexOptions);
+
+  console.info(`Vertex project: ${config.vertexOptions.project}`);
+  console.info(`Vertex location: ${config.vertexOptions.location}`);
+  console.info(`Vertex model: ${config.model}`);
+  console.info(`PDF source: ${gcsUri}`);
+  console.info(`Prompt: ${config.prompt}`);
+
+  const response = await ai.models.generateContent({
+    config: {
+      temperature: 0,
+    },
+    contents: [
+      {
+        parts: [
+          { text: config.prompt },
+          {
+            fileData: {
+              fileUri: gcsUri,
+              mimeType: VERTEX_NATIVE_PDF_MIME_TYPE,
+            },
+          },
+        ],
+        role: 'user',
+      },
+    ],
+    model: config.model,
+  });
+
+  const text = extractResponseText(response);
+
+  console.info('\nModel response:\n');
+  console.info(text || '(empty response)');
+
+  if (response.usageMetadata) {
+    console.info('\nUsage metadata:');
+    console.info(JSON.stringify(response.usageMetadata, null, 2));
+  }
+
+  if (config.prompt === DEFAULT_PROMPT) {
+    const verified = /\b123\b/.test(text);
+    console.info(
+      `\nVerification: ${verified ? 'PASS' : 'CHECK_MANUALLY'} (expected to mention 123)`,
+    );
+  }
+};
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -2,6 +2,7 @@ import { type ChatCompletionErrorPayload, type ModelRuntime } from '@lobechat/mo
 import { AGENT_RUNTIME_ERROR_SET } from '@lobechat/model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 
+import { prepareVertexNativePdfMessages } from '@/_custom/services/vertexNativePdf';
 import { checkAuth } from '@/app/(backend)/middleware/auth';
 import { createTraceOptions, initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { type ChatStreamPayload } from '@/types/openai/chat';
@@ -30,6 +31,14 @@ export const POST = checkAuth(
       // ============  2. create chat completion   ============ //
 
       const data = (await req.json()) as ChatStreamPayload;
+
+      if (provider === 'vertexai') {
+        data.messages = await prepareVertexNativePdfMessages({
+          messages: data.messages,
+          serverDB,
+          userId,
+        });
+      }
 
       const tracePayload = getTracePayload(req);
 

--- a/src/app/[variants]/(main)/home/_layout/HomeAgentIdSync.tsx
+++ b/src/app/[variants]/(main)/home/_layout/HomeAgentIdSync.tsx
@@ -1,16 +1,40 @@
 import { useUnmount } from 'ahooks';
+import isEqual from 'fast-deep-equal';
+import { useEffect, useRef } from 'react';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { useAgentStore } from '@/store/agent';
-import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 
 const HomeAgentIdSync = () => {
   const useAgentStoreUpdater = createStoreUpdater(useAgentStore);
 
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+  const clearEnabledFiles = useAgentStore((s) => s.clearEnabledFiles);
+  const inboxAgentFiles = useAgentStore(
+    (s) => agentByIdSelectors.getAgentFilesById(inboxAgentId || '')(s),
+    isEqual,
+  );
+  const isInboxAgentLoaded = useAgentStore((s) => !!(inboxAgentId && s.agentMap[inboxAgentId]));
+  const clearedInboxFilesRef = useRef<string | undefined>(undefined);
 
   // Sync inbox agent id to activeAgentId when on home page
   useAgentStoreUpdater('activeAgentId', inboxAgentId);
+
+  useEffect(() => {
+    clearedInboxFilesRef.current = undefined;
+  }, [inboxAgentId]);
+
+  useEffect(() => {
+    if (!inboxAgentId || !isInboxAgentLoaded) return;
+    if (clearedInboxFilesRef.current === inboxAgentId) return;
+
+    clearedInboxFilesRef.current = inboxAgentId;
+
+    if (inboxAgentFiles.some((file) => file.enabled)) {
+      void clearEnabledFiles(inboxAgentId);
+    }
+  }, [clearEnabledFiles, inboxAgentFiles, inboxAgentId, isInboxAgentLoaded]);
 
   // Clear activeAgentId when unmounting (leaving home page)
   useUnmount(() => {

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -5,6 +5,7 @@ import { type ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { getThinkingLevel3Default } from '@/_custom/registry/modelCustomization';
 import EffortSlider from '@/features/ChatInput/ActionBar/Model/EffortSlider';
 import GPT5ReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from '@/features/ChatInput/ActionBar/Model/GPT51ReasoningEffortSlider';
@@ -250,7 +251,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       thinkingBudget: <ThinkingBudgetSlider defaultValue={2 * 1024} />,
       thinkingLevel: <ThinkingLevelSlider value="high" />,
       thinkingLevel2: <ThinkingLevel2Slider value="high" />,
-      thinkingLevel3: <ThinkingLevel3Slider value="high" />,
+      thinkingLevel3: <ThinkingLevel3Slider value={getThinkingLevel3Default()} />,
       urlContext: <Switch checked disabled />,
     }),
     [],

--- a/src/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider.tsx
+++ b/src/features/ChatInput/ActionBar/Model/ThinkingLevel3Slider.tsx
@@ -1,3 +1,5 @@
+import { getThinkingLevel3Default } from '@/_custom/registry/modelCustomization';
+
 import { type CreatedLevelSliderProps } from './createLevelSlider';
 import { createLevelSliderComponent } from './createLevelSlider';
 
@@ -8,7 +10,7 @@ export type ThinkingLevel3SliderProps = CreatedLevelSliderProps<ThinkingLevel3>;
 
 const ThinkingLevel3Slider = createLevelSliderComponent<ThinkingLevel3>({
   configKey: 'thinkingLevel',
-  defaultValue: 'high',
+  defaultValue: getThinkingLevel3Default(),
   levels: THINKING_LEVELS_3,
   style: { minWidth: 160 },
 });

--- a/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
+++ b/src/features/ModelSwitchPanel/components/ModelDetailPanel.tsx
@@ -29,6 +29,7 @@ import { type FC, type ReactNode } from 'react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { resolveModelDetailDescription } from '@/_custom/registry/modelCustomization';
 import { formatTokenNumber } from '@/utils/format';
 import { formatPriceByCurrency, getTextInputUnitRate, getTextOutputUnitRate } from '@/utils/index';
 
@@ -242,7 +243,13 @@ const ModelDetailPanel: FC<ModelDetailPanelProps> = memo(({ extraControls, model
           </Text>
         </Flexbox>
         {model.description && (
-          <div className={styles.description}>{tModels(`${model.id}.description`)}</div>
+          <div className={styles.description}>
+            {resolveModelDetailDescription({
+              fallbackDescription: tModels(`${model.id}.description`),
+              modelId: model.id,
+              modelDescription: model.description,
+            })}
+          </div>
         )}
       </Flexbox>
       <Divider size="small" />

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -276,8 +276,29 @@ export const contextEngineering = async ({
   const agentKnowledgeBases = agentSelectors.currentAgentKnowledgeBases(agentStoreState);
 
   const fileContents = agentFiles
-    .filter((file) => file.enabled && file.content)
-    .map((file) => ({ content: file.content!, fileId: file.id, filename: file.name }));
+    .filter((file) => {
+      if (!file.enabled) return false;
+
+      const fileType = file.type || (file as typeof file & { fileType?: string }).fileType;
+      const hasNativePdfMetadata =
+        fileType?.toLowerCase() === 'application/pdf' &&
+        typeof file.url === 'string' &&
+        file.url.length > 0;
+
+      return !!file.content || hasNativePdfMetadata;
+    })
+    .map((file) => {
+      const fileType = file.type || (file as typeof file & { fileType?: string }).fileType;
+
+      return {
+        content: file.content || '',
+        fileId: file.id,
+        fileType,
+        filename: file.name,
+        size: file.size,
+        url: file.url,
+      };
+    });
 
   const knowledgeBases = agentKnowledgeBases
     .filter((kb) => kb.enabled)

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -552,17 +552,17 @@ describe('resolveModelExtendParams', () => {
         expect(result.thinkingLevel).toBe('medium');
       });
 
-      it('should not set thinkingLevel when thinkingLevel3 is not configured', () => {
+      it('should default thinkingLevel to low when thinkingLevel3 is not configured', () => {
         const result = resolveModelExtendParams({
           chatConfig: {} as any,
           model: 'gemini-3.1-pro-preview',
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('low');
       });
 
-      it('should not read from thinkingLevel config key', () => {
+      it('should ignore thinkingLevel config key and still use low default', () => {
         const result = resolveModelExtendParams({
           chatConfig: {
             thinkingLevel: 'high',
@@ -571,7 +571,42 @@ describe('resolveModelExtendParams', () => {
           provider: 'google',
         });
 
-        expect(result.thinkingLevel).toBeUndefined();
+        expect(result.thinkingLevel).toBe('low');
+      });
+
+      it('should not override explicit thinkingLevel when both thinkingLevel and thinkingLevel3 are enabled', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'high',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('high');
+      });
+
+      it('should prioritize explicit thinkingLevel3 over thinkingLevel when both are enabled', () => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'thinkingLevel',
+          'thinkingLevel3',
+        ]);
+
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            thinkingLevel: 'low',
+            thinkingLevel3: 'medium',
+          } as any,
+          model: 'gemini-3.1-pro-preview',
+          provider: 'google',
+        });
+
+        expect(result.thinkingLevel).toBe('medium');
       });
     });
   });

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -1,5 +1,6 @@
 import { type LobeAgentChatConfig } from '@lobechat/types';
 
+import { getThinkingLevel3Default } from '@/_custom/registry/modelCustomization';
 import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 
 /**
@@ -148,8 +149,13 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
     extendParams.thinkingLevel = chatConfig.thinkingLevel2;
   }
 
-  if (modelExtendParams.includes('thinkingLevel3') && chatConfig.thinkingLevel3) {
-    extendParams.thinkingLevel = chatConfig.thinkingLevel3;
+  if (modelExtendParams.includes('thinkingLevel3')) {
+    if (chatConfig.thinkingLevel3) {
+      extendParams.thinkingLevel = chatConfig.thinkingLevel3;
+    } else if (!extendParams.thinkingLevel) {
+      // Only apply the v3 default when no explicit thinking level was set by other keys.
+      extendParams.thinkingLevel = getThinkingLevel3Default();
+    }
   }
 
   // URL context

--- a/src/store/agent/slices/knowledge/action.test.ts
+++ b/src/store/agent/slices/knowledge/action.test.ts
@@ -266,6 +266,74 @@ describe('KnowledgeSlice Actions', () => {
     });
   });
 
+  describe('clearEnabledFiles', () => {
+    it('should not call service if no activeAgentId', async () => {
+      const { result } = renderHook(() => useAgentStore());
+
+      await act(async () => {
+        await result.current.clearEnabledFiles();
+      });
+
+      expect(agentService.toggleFile).not.toHaveBeenCalled();
+    });
+
+    it('should not call service if there are no enabled files', async () => {
+      const { result } = renderHook(() => useAgentStore());
+
+      act(() => {
+        useAgentStore.setState({
+          activeAgentId: 'agent-1',
+          agentMap: {
+            'agent-1': {
+              files: [{ enabled: false, id: 'file-1', name: 'file-1.pdf' }],
+            } as any,
+          },
+        });
+      });
+
+      await act(async () => {
+        await result.current.clearEnabledFiles();
+      });
+
+      expect(agentService.toggleFile).not.toHaveBeenCalled();
+    });
+
+    it('should disable all enabled files and refresh config once', async () => {
+      const { result } = renderHook(() => useAgentStore());
+
+      vi.mocked(agentService.toggleFile).mockResolvedValue(undefined as any);
+
+      act(() => {
+        useAgentStore.setState({
+          activeAgentId: 'agent-1',
+          agentMap: {
+            'agent-1': {
+              files: [
+                { enabled: true, id: 'file-1', name: 'file-1.pdf' },
+                { enabled: false, id: 'file-2', name: 'file-2.pdf' },
+                { enabled: true, id: 'file-3', name: 'file-3.pdf' },
+              ],
+            } as any,
+          },
+        });
+      });
+
+      const refreshSpy = vi
+        .spyOn(result.current, 'internal_refreshAgentConfig')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.clearEnabledFiles();
+      });
+
+      expect(agentService.toggleFile).toHaveBeenCalledTimes(2);
+      expect(agentService.toggleFile).toHaveBeenCalledWith('agent-1', 'file-1', false);
+      expect(agentService.toggleFile).toHaveBeenCalledWith('agent-1', 'file-3', false);
+      expect(refreshSpy).toHaveBeenCalledWith('agent-1');
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('useFetchFilesAndKnowledgeBases', () => {
     it('should fetch files and knowledge bases for active agent', async () => {
       const mockData = [

--- a/src/store/agent/slices/knowledge/action.ts
+++ b/src/store/agent/slices/knowledge/action.ts
@@ -49,6 +49,26 @@ export class KnowledgeSliceActionImpl {
     await internal_refreshAgentKnowledge();
   };
 
+  clearEnabledFiles = async (agentId = this.#get().activeAgentId): Promise<void> => {
+    const { internal_refreshAgentConfig, agentMap } = this.#get();
+    if (!agentId) return;
+
+    const files =
+      (agentMap[agentId] as { files?: Array<{ enabled?: boolean; id: string }> } | undefined)
+        ?.files || [];
+
+    const enabledFileIds = files
+      .filter((file: { enabled?: boolean; id: string }) => file.enabled)
+      .map((file: { id: string }) => file.id);
+
+    if (enabledFileIds.length === 0) return;
+
+    await Promise.all(
+      enabledFileIds.map((id: string) => agentService.toggleFile(agentId, id, false)),
+    );
+    await internal_refreshAgentConfig(agentId);
+  };
+
   internal_refreshAgentKnowledge = async (): Promise<void> => {
     await mutate([FETCH_AGENT_KNOWLEDGE_KEY, this.#get().activeAgentId]);
   };

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -34,7 +34,14 @@ const createImageModel = (overrides: Partial<ImageEnabledModel> = {}): ImageEnab
 });
 
 describe('aiProvider action helpers', () => {
+  const originalDescriptionRewriteSwitch = process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE;
+
   afterEach(() => {
+    if (originalDescriptionRewriteSwitch === undefined) {
+      delete process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE;
+    } else {
+      process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE = originalDescriptionRewriteSwitch;
+    }
     vi.restoreAllMocks();
   });
 
@@ -54,6 +61,83 @@ describe('aiProvider action helpers', () => {
         displayName: '',
         id: 'chat-model',
       });
+    });
+
+    it('replaces built-in model name in description with custom display name', async () => {
+      process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE = '1';
+
+      vi.spyOn(runtimeModule, 'getModelPropertyWithFallback').mockImplementation(
+        async (_id, key) => {
+          if (key === 'displayName') return 'Gemini 3.1 Pro Preview';
+          if (key === 'description') {
+            return 'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities.';
+          }
+          return undefined;
+        },
+      );
+
+      const result = await normalizeChatModel(
+        createChatModel({
+          displayName: 'Cotti-Pro',
+          id: 'gemini-3.1-pro-preview',
+          providerId: 'vertexai',
+        }),
+      );
+
+      expect(result.displayName).toBe('Cotti-Pro');
+      expect(result.description).toContain('Cotti-Pro improves on Cotti-Pro');
+      expect(result.description).not.toContain('Gemini 3.1 Pro Preview');
+      expect(result.description).not.toContain('Gemini 3 Pro');
+    });
+
+    it('keeps advanced alias replacement disabled when env switch is off', async () => {
+      process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE = '0';
+
+      vi.spyOn(runtimeModule, 'getModelPropertyWithFallback').mockImplementation(
+        async (_id, key) => {
+          if (key === 'displayName') return 'Gemini 3.1 Pro Preview';
+          if (key === 'description') {
+            return 'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities.';
+          }
+          return undefined;
+        },
+      );
+
+      const result = await normalizeChatModel(
+        createChatModel({
+          displayName: 'Cotti-Pro',
+          id: 'gemini-3.1-pro-preview',
+          providerId: 'vertexai',
+        }),
+      );
+
+      expect(result.description).toContain('Cotti-Pro improves on Gemini 3 Pro');
+      expect(result.description).not.toContain('Gemini 3.1 Pro Preview');
+    });
+
+    it('rewrites preview display-name variants in description', async () => {
+      process.env.NEXT_PUBLIC_MODEL_ALIAS_DESCRIPTION_REWRITE = '1';
+
+      vi.spyOn(runtimeModule, 'getModelPropertyWithFallback').mockImplementation(
+        async (_id, key) => {
+          if (key === 'displayName') return 'Gemini 3 Flash Preview';
+          if (key === 'description') {
+            return 'Gemini 3 Flash is the smartest model built for speed.';
+          }
+          return undefined;
+        },
+      );
+
+      const result = await normalizeChatModel(
+        createChatModel({
+          displayName: 'Cotti-Flash',
+          id: 'gemini-3-flash-preview',
+          providerId: 'vertexai',
+        }),
+      );
+
+      expect(result.description).toContain('Cotti-Flash is the smartest model');
+      expect(result.description).not.toContain('Gemini 3 Flash');
     });
   });
 

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -10,6 +10,7 @@ import {
 } from 'model-bank';
 import { type SWRResponse } from 'swr';
 
+import { resolveCustomizedModelDescription } from '@/_custom/registry/modelCustomization';
 import { mapProviderListName, resolveProviderName } from '@/_custom/registry/providerName';
 import { filterHiddenProviders } from '@/_custom/registry/providerVisibility';
 import { mutate, useClientDataSWR } from '@/libs/swr';
@@ -65,10 +66,11 @@ const createProviderModelCollector = (
 };
 
 export const normalizeChatModel = async (model: EnabledAiModel): Promise<ProviderModelListItem> => {
-  const [description, pricing] = await Promise.all([
+  const [fallbackDescription, pricing] = await Promise.all([
     getModelPropertyWithFallback<string | undefined>(model.id, 'description', model.providerId),
     getModelPropertyWithFallback<Pricing | undefined>(model.id, 'pricing', model.providerId),
   ]);
+  const description = await resolveCustomizedModelDescription({ fallbackDescription, model });
 
   return {
     abilities: (model.abilities || {}) as ModelAbilities,

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -1,3 +1,4 @@
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import { type UIChatMessage } from '@lobechat/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { type Mock } from 'vitest';
@@ -8,6 +9,7 @@ import { mutate } from '@/libs/swr';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
+import { useAgentStore } from '@/store/agent';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useSessionStore } from '@/store/session';
@@ -82,6 +84,16 @@ beforeEach(() => {
       pinnedSessions: [],
       sessions: [],
       isSessionsFirstFetchFinished: false,
+    },
+    false,
+  );
+  useAgentStore.setState(
+    {
+      activeAgentId: undefined,
+      agentMap: {},
+      builtinAgentIdMap: {},
+      updateAgentConfigSignal: undefined,
+      updateAgentMetaSignal: undefined,
     },
     false,
   );
@@ -592,6 +604,58 @@ describe('topic action', () => {
 
       // Verify activeTopicId is now null
       expect(useChatStore.getState().activeTopicId).toBeNull();
+    });
+
+    it('should clear enabled related files when switching to a new topic for inbox agent', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const activeAgentId = 'inbox-agent-id';
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId,
+          activeTopicId: 'existing-topic',
+        });
+        useAgentStore.setState({
+          activeAgentId,
+          builtinAgentIdMap: { [INBOX_SESSION_ID]: activeAgentId },
+        });
+      });
+
+      const clearEnabledFilesSpy = vi
+        .spyOn(useAgentStore.getState(), 'clearEnabledFiles')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.switchTopic(null, { skipRefreshMessage: true });
+      });
+
+      expect(clearEnabledFilesSpy).toHaveBeenCalledWith(activeAgentId);
+    });
+
+    it('should not clear enabled related files when switching to a new topic for custom agent', async () => {
+      const { result } = renderHook(() => useChatStore());
+      const activeAgentId = 'custom-agent-id';
+
+      await act(async () => {
+        useChatStore.setState({
+          activeAgentId,
+          activeTopicId: 'existing-topic',
+        });
+        useAgentStore.setState({
+          activeAgentId,
+          builtinAgentIdMap: { [INBOX_SESSION_ID]: 'inbox-agent-id' },
+        });
+      });
+
+      const clearEnabledFilesSpy = vi
+        .spyOn(useAgentStore.getState(), 'clearEnabledFiles')
+        .mockResolvedValue(undefined);
+
+      await act(async () => {
+        await result.current.switchTopic(null, { skipRefreshMessage: true });
+      });
+
+      expect(clearEnabledFilesSpy).not.toHaveBeenCalled();
     });
 
     it('should clear new key data when switching to null (group scope)', async () => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -15,6 +15,8 @@ import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
+import { getAgentStoreState } from '@/store/agent';
+import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { type ChatStore } from '@/store/chat';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useGlobalStore } from '@/store/global';
@@ -495,6 +497,7 @@ export class ChatTopicActionImpl {
     const opts = options ?? {};
 
     const { activeAgentId, activeGroupId } = this.#get();
+    const shouldClearRelatedFiles = !id && !!activeAgentId && !activeGroupId;
 
     // Clear the _new key data in the following cases:
     // 1. When id is null or undefined (switching to empty topic state)
@@ -523,6 +526,14 @@ export class ChatTopicActionImpl {
       false,
       n('toggleTopic'),
     );
+
+    if (shouldClearRelatedFiles) {
+      const agentStore = getAgentStoreState();
+
+      if (builtinAgentSelectors.inboxAgentId(agentStore) === activeAgentId) {
+        void agentStore.clearEnabledFiles(activeAgentId);
+      }
+    }
 
     if (id) {
       this.#get().clearUnreadCompletedTopic(id);

--- a/src/store/file/slices/chat/action.test.ts
+++ b/src/store/file/slices/chat/action.test.ts
@@ -1,5 +1,10 @@
-import { act, renderHook } from '@testing-library/react';
+import { DocumentSourceType, type LobeDocument } from '@lobechat/types';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { notification } from '@/components/AntdStaticMethods';
+import { ragService } from '@/services/rag';
+import { initialState } from '@/store/file/initialState';
 
 import { useFileStore as useStore } from '../../store';
 
@@ -10,6 +15,16 @@ vi.mock('@/components/AntdStaticMethods', () => ({
   notification: {
     error: vi.fn(),
   },
+}));
+
+vi.mock('@/services/rag', () => ({
+  ragService: {
+    parseFileContent: vi.fn(),
+  },
+}));
+
+vi.mock('i18next', () => ({
+  t: (key: string, options?: Record<string, any>) => options?.reason ?? key,
 }));
 
 beforeAll(() => {
@@ -29,6 +44,13 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  useStore.setState(
+    {
+      chatContextSelections: initialState.chatContextSelections,
+      chatUploadFileList: initialState.chatUploadFileList,
+    },
+    false,
+  );
 });
 
 describe('useFileStore:chat', () => {
@@ -46,5 +68,120 @@ describe('useFileStore:chat', () => {
     });
 
     expect(result.current.chatUploadFileList).toEqual([]);
+  });
+
+  it('uploadChatFiles should keep PDF attachments processing until parseFileContent resolves', async () => {
+    const { result } = renderHook(() => useStore());
+    const file = new File(['resume'], 'resume.pdf', { type: 'application/pdf' });
+    const parsedDocument: LobeDocument = {
+      content: 'resume content',
+      createdAt: new Date('2026-03-09T00:00:00.000Z'),
+      editorData: null,
+      filename: 'resume.pdf',
+      fileType: 'application/pdf',
+      id: 'doc-1',
+      metadata: {},
+      source: 'files://resume.pdf',
+      sourceType: DocumentSourceType.FILE,
+      totalCharCount: 14,
+      totalLineCount: 1,
+      updatedAt: new Date('2026-03-09T00:00:00.000Z'),
+    };
+
+    let resolveParse!: () => void;
+    const parsePromise = new Promise<LobeDocument>((resolve) => {
+      resolveParse = () => resolve(parsedDocument);
+    });
+
+    vi.spyOn(useStore.getState(), 'uploadWithProgress').mockImplementation(
+      async ({ file, onStatusUpdate }) => {
+        onStatusUpdate?.({
+          id: file.name,
+          type: 'updateFile',
+          value: {
+            fileUrl: 'https://example.com/resume.pdf',
+            id: 'file-1',
+            status: 'success',
+            uploadState: { progress: 100, restTime: 0, speed: 0 },
+          },
+        });
+
+        return { id: 'file-1', url: 'https://example.com/resume.pdf' };
+      },
+    );
+
+    vi.mocked(ragService.parseFileContent).mockImplementation(() => parsePromise);
+
+    const uploadTask = result.current.uploadChatFiles([file]);
+
+    await waitFor(() => {
+      expect(useStore.getState().chatUploadFileList).toEqual([
+        expect.objectContaining({
+          id: 'file-1',
+          status: 'processing',
+          uploadState: { progress: 100, restTime: 0, speed: 0 },
+        }),
+      ]);
+    });
+
+    resolveParse();
+    await uploadTask;
+
+    await waitFor(() => {
+      expect(useStore.getState().chatUploadFileList).toEqual([
+        expect.objectContaining({
+          id: 'file-1',
+          status: 'success',
+          tasks: undefined,
+        }),
+      ]);
+    });
+
+    expect(ragService.parseFileContent).toHaveBeenCalledWith('file-1');
+  });
+
+  it('uploadChatFiles should surface parse errors and keep the broken file blocked', async () => {
+    const { result } = renderHook(() => useStore());
+    const file = new File(['resume'], 'resume.pdf', { type: 'application/pdf' });
+
+    vi.spyOn(useStore.getState(), 'uploadWithProgress').mockImplementation(
+      async ({ file, onStatusUpdate }) => {
+        onStatusUpdate?.({
+          id: file.name,
+          type: 'updateFile',
+          value: {
+            fileUrl: 'https://example.com/resume.pdf',
+            id: 'file-2',
+            status: 'success',
+            uploadState: { progress: 100, restTime: 0, speed: 0 },
+          },
+        });
+
+        return { id: 'file-2', url: 'https://example.com/resume.pdf' };
+      },
+    );
+
+    vi.mocked(ragService.parseFileContent).mockRejectedValue(new Error('parse failed'));
+
+    await result.current.uploadChatFiles([file]);
+
+    await waitFor(() => {
+      expect(useStore.getState().chatUploadFileList).toEqual([
+        expect.objectContaining({
+          id: 'file-2',
+          status: 'success',
+          tasks: expect.objectContaining({
+            chunkingStatus: 'error',
+            finishEmbedding: false,
+          }),
+        }),
+      ]);
+    });
+
+    expect(notification.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'parse failed',
+      }),
+    );
   });
 });

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -9,6 +9,7 @@ import { UPLOAD_NETWORK_ERROR } from '@/services/upload';
 import { type UploadFileListDispatch } from '@/store/file/reducers/uploadFileList';
 import { uploadFileListReducer } from '@/store/file/reducers/uploadFileList';
 import { type StoreSetter } from '@/store/types';
+import { AsyncTaskStatus, type IAsyncTaskError } from '@/types/asyncTask';
 import { type FileListItem } from '@/types/files';
 import { type UploadFileItem } from '@/types/files/upload';
 import { isChunkingUnsupported } from '@/utils/isChunkingUnsupported';
@@ -18,6 +19,20 @@ import { setNamespace } from '@/utils/storeDebug';
 import { type FileStore } from '../../store';
 
 const n = setNamespace('chat');
+
+const toAsyncTaskError = (error: unknown): IAsyncTaskError => {
+  const reason =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? error.message
+        : t('upload.unknownError', { ns: 'error', reason: 'Unknown error' });
+
+  return {
+    body: { detail: reason },
+    name: error instanceof Error ? error.name : 'ParseFileContentError',
+  };
+};
 
 type Setter = StoreSetter<FileStore>;
 export const createFileSlice = (set: Setter, get: () => FileStore, _api?: unknown) =>
@@ -163,8 +178,49 @@ export class FileActionImpl {
       // image don't need to be chunked and embedding
       if (isChunkingUnsupported(file.type)) return;
 
-      const data = await ragService.parseFileContent(fileResult.id);
-      console.log('parseFileContent data:', data);
+      dispatchChatUploadFileList({
+        id: fileResult.id,
+        type: 'updateFile',
+        value: {
+          status: 'processing',
+          tasks: undefined,
+          uploadState: { progress: 100, restTime: 0, speed: 0 },
+        },
+      });
+
+      try {
+        await ragService.parseFileContent(fileResult.id);
+
+        dispatchChatUploadFileList({
+          id: fileResult.id,
+          type: 'updateFile',
+          value: {
+            status: 'success',
+            tasks: undefined,
+          },
+        });
+      } catch (error) {
+        notification.error({
+          description:
+            typeof error === 'string'
+              ? error
+              : t('upload.unknownError', { ns: 'error', reason: (error as Error).message }),
+          message: t('upload.uploadFailed', { ns: 'error' }),
+        });
+
+        dispatchChatUploadFileList({
+          id: fileResult.id,
+          type: 'updateFile',
+          value: {
+            status: 'success',
+            tasks: {
+              chunkingError: toAsyncTaskError(error),
+              chunkingStatus: AsyncTaskStatus.Error,
+              finishEmbedding: false,
+            },
+          },
+        });
+      }
     });
 
     await Promise.all(pools);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- Related to custom sync and stability alignment work (2026-03-09)

#### 🔀 Description of Change

Sync `dev` into `main` with two key groups:

1. Vertex/Google 400-risk stabilization (aligned with stable upstream handling)
- normalize guard behavior in Google context/thinking resolver paths
- add/adjust tests for context builder and thinking resolver
- add hotfix verification script checks

2. Custom behavior refinement
- refine model alias description fallback strategy
- fix `thinkingLevel3` default precedence so explicit settings are not overridden
- add custom registry + tests

Also includes handoff docs and custom changelog updates under `src/_custom/`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Executed locally:
- `bun run type-check`
- `bun run custom:verify-hotfixes`
- targeted vitest suites for model params / provider actions / Google runtime paths
- docker deploy smoke on `dev` (`docker compose ... up -d --build`, service up on `:3210`)

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

`main` is protected in this repo, so merge must go through PR checks.
